### PR TITLE
Refactor examples to builder-driven agent usage

### DIFF
--- a/examples/base_tool/README.md
+++ b/examples/base_tool/README.md
@@ -1,6 +1,6 @@
 # Example: Base Tool (v4.0)
 
-该目录展示 v4.0 工具运行时的最小可运行示例，包括：
+该目录展示 v4.0 工具运行时的最小可运行示例（基于 Builder 组装），包括：
 - 可信工具目录（Tool Gateway Registry）
 - 内置文件工具集（read/search/write/edit）
 - 通过大模型进行工具调用的最小闭环
@@ -10,8 +10,8 @@
 ```
 base_tool/
 ├── README.md           # 本文件
-├── v4_tooling.py       # v4.0 工具运行时（直接调用）
-└── tool_chat3.4.py     # v4.0 工具调用（模型驱动）
+├── v4_tooling.py       # v4.0 工具运行时（Builder 组装后直接调用）
+└── tool_chat3.4.py     # v4.0 工具调用（Builder 组装 + 模型驱动）
 ```
 
 ## 运行方式
@@ -27,7 +27,7 @@ PYTHONPATH=. python examples/base_tool/v4_tooling.py
 - `TOOL_READ_PATH`：示例读取文件路径（默认 `examples/base_tool/README.md`）
 - `TOOL_LOG_LEVEL`：日志级别（默认 `INFO`）
 
-### 2) 通过大模型调用工具（手动 Tool Loop）
+### 2) 通过大模型调用工具（ReAct Loop）
 
 ```bash
 PYTHONPATH=. python examples/base_tool/tool_chat3.4.py
@@ -39,10 +39,9 @@ PYTHONPATH=. python examples/base_tool/tool_chat3.4.py
 - `CHAT_ENDPOINT`：模型网关地址（默认 DashScope 兼容端点）
 - `CHAT_LOG_LEVEL`：日志级别（默认 `INFO`）
 - `TOOL_WORKSPACE_ROOT`：工作目录根（默认 `.`）
-- `TOOL_MAX_ROUNDS`：最大工具轮次（默认 `3`）
 
 ## 注意事项
 
-- 以上示例依赖 `langchain-openai`（见 `requirements.txt`）
+- `tool_chat3.4.py` 依赖 `langchain-openai`（见 `requirements.txt`）
 - `run_command` 为高风险工具；示例仅演示调用链，不包含审批流程
 - 文件工具默认限制在 `workspace_roots` 内，且受 guardrails（max_bytes/max_results）约束

--- a/examples/base_tool/tool_chat3.4.py
+++ b/examples/base_tool/tool_chat3.4.py
@@ -1,9 +1,9 @@
-"""Tool-chat example using dare_framework.
+"""Tool-chat example using dare_framework (builder-based).
 
 Demonstrates a minimal tool-calling loop with:
 - OpenAI-compatible model adapter
 - Trusted tool definitions from the gateway registry
-- Manual tool execution + tool result round-trip
+- FiveLayerAgent ReAct loop via Builder (no manual context wiring)
 """
 
 from __future__ import annotations
@@ -14,17 +14,14 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any
 
 # Add project root to path for local development
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from dare_framework.context import Budget, Context, Message
-from dare_framework.memory import InMemorySTM
-from dare_framework.model import OpenAIModelAdapter, Prompt
-from dare_framework.plan import Envelope
+from dare_framework.builder import Builder
+from dare_framework.model import OpenAIModelAdapter
 from dare_framework.tool import (
     DefaultToolGateway,
     EditLineTool,
@@ -44,7 +41,6 @@ ENDPOINT = os.getenv("CHAT_ENDPOINT", "https://dashscope.aliyuncs.com/compatible
 HTTP_CLIENT_OPTIONS = {"trust_env": False, "proxy": None}
 LOG_LEVEL = os.getenv("CHAT_LOG_LEVEL", "INFO").upper()
 WORKSPACE_ROOT = os.getenv("TOOL_WORKSPACE_ROOT", ".")
-MAX_TOOL_ROUNDS = int(os.getenv("TOOL_MAX_ROUNDS", "3"))
 
 logger = logging.getLogger("tool-chat-v3_4")
 
@@ -55,57 +51,7 @@ def _preview(text: str, limit: int = 200) -> str:
     return f"{text[:limit]}...<truncated>"
 
 
-def _serialize_messages(messages: list[Message]) -> list[dict[str, Any]]:
-    serialized: list[dict[str, Any]] = []
-    for msg in messages:
-        serialized.append(
-            {
-                "role": msg.role,
-                "content": msg.content,
-                "name": msg.name,
-                "metadata": dict(msg.metadata),
-            }
-        )
-    return serialized
-
-
-def _log_llm_request(prompt: Prompt) -> None:
-    request_body = {
-        "messages": _serialize_messages(prompt.messages),
-        "tools": prompt.tools,
-        "metadata": prompt.metadata,
-    }
-    logger.info("llm request body", extra={"request_body": request_body})
-    print(json.dumps({"llm_request": request_body}, indent=2, sort_keys=True, ensure_ascii=False))
-
-
-def _log_llm_response(response) -> None:
-    response_body = {
-        "content": response.content,
-        "tool_calls": response.tool_calls,
-        "usage": response.usage,
-        "metadata": response.metadata,
-    }
-    logger.info("llm response body", extra={"response_body": response_body})
-    print(json.dumps({"llm_response": response_body}, indent=2, sort_keys=True, ensure_ascii=False))
-
-
-def _log_messages(messages: list[Message], *, label: str) -> None:
-    logger.info(label, extra={"message_count": len(messages)})
-    for idx, msg in enumerate(messages, start=1):
-        logger.debug(
-            "message",
-            extra={
-                "index": idx,
-                "role": msg.role,
-                "name": msg.name,
-                "content": _preview(msg.content),
-                "metadata_keys": list(msg.metadata.keys()),
-            },
-        )
-
-
-def _log_tool_defs(tool_defs: list[dict[str, Any]]) -> None:
+def _log_tool_defs(tool_defs: list[dict[str, object]]) -> None:
     tool_names = []
     for tool in tool_defs:
         function = tool.get("function") if isinstance(tool, dict) else None
@@ -114,78 +60,18 @@ def _log_tool_defs(tool_defs: list[dict[str, Any]]) -> None:
     logger.info("tool defs loaded", extra={"tool_names": tool_names})
 
 
-async def _execute_tool_calls(
-    response,
-    *,
-    gateway: DefaultToolGateway,
-    context: Context,
-) -> bool:
-    tool_calls = response.tool_calls
-    if not tool_calls:
-        return False
-
-    context.stm_add(
-        Message(
-            role="assistant",
-            content=response.content or "",
-            metadata={"tool_calls": tool_calls},
-        )
-    )
-
-    for idx, call in enumerate(tool_calls, start=1):
-        tool_name = call.get("name")
-        if not tool_name:
-            logger.warning("tool call missing name", extra={"call": call})
-            continue
-        arguments = call.get("arguments") or {}
-        if not isinstance(arguments, dict):
-            arguments = {"raw": arguments}
-        call_id = call.get("id") or f"tool_call_{idx}"
-        capability_id = f"tool:{tool_name}"
-
-        logger.info(
-            "invoking tool",
-            extra={
-                "capability_id": capability_id,
-                "call_id": call_id,
-                "arguments": arguments,
-            },
-        )
+def _format_output(output: object | None) -> str:
+    if output is None:
+        return ""
+    if isinstance(output, dict):
+        content = output.get("content")
+        if content:
+            return str(content)
         try:
-            result = await gateway.invoke(
-                capability_id,
-                arguments,
-                envelope=Envelope(allowed_capability_ids=[capability_id]),
-            )
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("tool invocation failed")
-            result_payload = {"success": False, "error": str(exc)}
-        else:
-            result_payload = {
-                "success": result.success,
-                "output": result.output,
-                "error": result.error,
-            }
-            logger.info(
-                "tool invocation result",
-                extra={
-                    "capability_id": capability_id,
-                    "call_id": call_id,
-                    "success": result.success,
-                    "error": result.error,
-                },
-            )
-
-        context.stm_add(
-            Message(
-                role="tool",
-                name=call_id,
-                content=json.dumps(result_payload),
-                metadata={"tool_name": tool_name},
-            )
-        )
-
-    return True
+            return json.dumps(output, indent=2, sort_keys=True, ensure_ascii=False)
+        except TypeError:
+            return str(output)
+    return str(output)
 
 
 async def main() -> None:
@@ -236,18 +122,26 @@ async def main() -> None:
     ]
 
     gateway = DefaultToolGateway()
-    gateway.register_provider(NativeToolProvider(tools=tools, context_factory=run_context.build))
+    provider = NativeToolProvider(
+        tools=tools,
+        context_factory=run_context.build,
+        # Align capability ids with tool call names emitted by the model.
+        capability_prefix="",
+    )
+    gateway.register_provider(provider)
 
+    # Inject a tool provider so we can refresh tool defs asynchronously in this loop.
     tool_provider = GatewayToolProvider(gateway)
     await tool_provider.refresh()
     _log_tool_defs(tool_provider.list_tools())
 
-    context = Context(
-        id="tool-chat-v3_4",
-        short_term_memory=InMemorySTM(),
-        budget=Budget(),
+    agent = (
+        Builder.five_layer_agent_builder("tool-chat-v3_4")
+        .with_model(model_adapter)
+        .with_tool_gateway(gateway)
+        .with_tool_provider(tool_provider)
+        .build()
     )
-    context._tool_provider = tool_provider
 
     print("Tool Chat v3.4 - Type your message (or /quit to exit):", flush=True)
     while True:
@@ -261,52 +155,23 @@ async def main() -> None:
         if prompt == "/quit":
             break
 
-        context.stm_add(Message(role="user", content=prompt))
-        assembled = context.assemble()
-        _log_messages(assembled.messages, label="assembled prompt")
-        logger.info("llm request", extra={"tools": len(assembled.tools)})
-        prompt_payload = Prompt(messages=assembled.messages, tools=assembled.tools, metadata=assembled.metadata)
-        _log_llm_request(prompt_payload)
-        response = await model_adapter.generate(prompt_payload)
-        logger.info(
-            "llm response",
-            extra={
-                "content": _preview(response.content),
-                "tool_call_count": len(response.tool_calls),
-                "usage": response.usage,
-            },
-        )
-        _log_llm_response(response)
+        logger.info("running prompt", extra={"prompt": _preview(prompt)})
+        try:
+            result = await agent.run(prompt)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("agent run failed")
+            print(f"[error] model call failed: {exc}", file=sys.stderr, flush=True)
+            continue
 
-        rounds = 0
-        while response.tool_calls and rounds < MAX_TOOL_ROUNDS:
-            rounds += 1
-            logger.info("tool calls detected", extra={"count": len(response.tool_calls), "round": rounds})
-            await _execute_tool_calls(response, gateway=gateway, context=context)
-            assembled = context.assemble()
-            _log_messages(assembled.messages, label="assembled prompt (post-tool)")
-            logger.info("llm request (post-tool)", extra={"tools": len(assembled.tools)})
-            prompt_payload = Prompt(messages=assembled.messages, tools=assembled.tools, metadata=assembled.metadata)
-            _log_llm_request(prompt_payload)
-            response = await model_adapter.generate(prompt_payload)
-            logger.info(
-                "llm response (post-tool)",
-                extra={
-                    "content": _preview(response.content),
-                    "tool_call_count": len(response.tool_calls),
-                    "usage": response.usage,
-                },
-            )
-            _log_llm_response(response)
+        content = _format_output(result.output)
+        if not content:
+            if result.errors:
+                print(f"[error] {', '.join(result.errors)}", file=sys.stderr, flush=True)
+            else:
+                print("No output returned.", flush=True)
+            continue
 
-        if response.tool_calls and rounds >= MAX_TOOL_ROUNDS:
-            logger.warning("tool rounds exhausted", extra={"max_rounds": MAX_TOOL_ROUNDS})
-
-        if response.content:
-            context.stm_add(Message(role="assistant", content=response.content))
-            print(response.content, flush=True)
-        else:
-            print("No output returned.", flush=True)
+        print(content, flush=True)
 
 
 if __name__ == "__main__":

--- a/examples/base_tool/v4_tooling.py
+++ b/examples/base_tool/v4_tooling.py
@@ -1,4 +1,4 @@
-"""V4 tooling example using dare_framework.
+"""V4 tooling example using dare_framework (builder-based).
 
 Demonstrates the v4.0 tool runtime with:
 - Built-in file tools
@@ -19,12 +19,14 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from dare_framework.builder import Builder
+from dare_framework.infra.component import ComponentType
+from dare_framework.model import IModelAdapter
 from dare_framework.plan import Envelope
 from dare_framework.tool import (
     DefaultToolGateway,
     EditLineTool,
     GatewayToolProvider,
-    NativeToolProvider,
     NoOpTool,
     ReadFileTool,
     RunCommandTool,
@@ -32,6 +34,21 @@ from dare_framework.tool import (
     SearchCodeTool,
     WriteFileTool,
 )
+
+
+# Builder requires a model adapter even when this example only exercises tools.
+class _NoopModelAdapter(IModelAdapter):
+    @property
+    def name(self) -> str:
+        return "noop-model-adapter"
+
+    @property
+    def component_type(self) -> ComponentType:
+        return ComponentType.MODEL_ADAPTER
+
+    async def generate(self, prompt, *, options=None):  # type: ignore[override]
+        raise RuntimeError("NoopModelAdapter is not intended for model generation.")
+
 
 # Configuration
 WORKSPACE_ROOT = os.getenv("TOOL_WORKSPACE_ROOT", ".")
@@ -69,12 +86,20 @@ async def run_read_file(workspace_root: str, read_path: str):
     ]
 
     gateway = DefaultToolGateway()
-    gateway.register_provider(NativeToolProvider(tools=tools, context_factory=run_context.build))
-
+    # Inject a tool provider so we can refresh tool defs asynchronously in this loop.
     tool_provider = GatewayToolProvider(gateway)
-    await tool_provider.refresh()
+    builder = (
+        Builder.simple_chat_agent_builder("v4-tooling")
+        .with_model(_NoopModelAdapter())
+        .with_tool_gateway(gateway)
+        .with_tool_provider(tool_provider)
+        .with_run_context_factory(run_context.build)
+        .add_tools(*tools)
+    )
+    agent = builder.build()
 
-    tool_defs = tool_provider.list_tools()
+    await tool_provider.refresh()
+    tool_defs = agent.context.listing_tools()
     result = await gateway.invoke(
         "tool:read_file",
         {"path": read_path},

--- a/examples/basic-chat/README.md
+++ b/examples/basic-chat/README.md
@@ -24,6 +24,6 @@ Type messages and press Enter. Use `/quit` to exit.
 
 ## Available variants
 
-- `chat_simple.py`: minimal direct `SimpleChatAgent` usage with inline configuration.
-- `chat_env.py`: configuration via environment variables (and optional debug context logging).
-- `chat_builder.py`: composition via `AgentBuilder` for teams that prefer builder-style wiring.
+- `chat_simple.py`: minimal builder-based chat with inline configuration.
+- `chat_env.py`: builder-based configuration via environment variables (and optional debug context logging).
+- `chat_builder.py`: explicit builder wiring with the same chat flow.

--- a/examples/basic-chat/chat_builder.py
+++ b/examples/basic-chat/chat_builder.py
@@ -1,4 +1,4 @@
-"""Chat example using AgentBuilder for composition."""
+"""Chat example using Builder for composition."""
 
 from __future__ import annotations
 

--- a/examples/basic-chat/chat_env.py
+++ b/examples/basic-chat/chat_env.py
@@ -1,4 +1,4 @@
-"""Chat example configured via environment variables."""
+"""Chat example configured via environment variables (builder-based)."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from dare_framework.agent import SimpleChatAgent
+from dare_framework.builder import Builder
 from dare_framework.model import OpenAIModelAdapter
 
 # Configuration
@@ -58,10 +58,7 @@ async def main() -> None:
     )
     logger.info("using OpenAIModelAdapter")
 
-    agent = SimpleChatAgent(
-        name="basic-chat-env",
-        model=model_adapter,
-    )
+    agent = Builder.simple_chat_agent_builder("basic-chat-env").with_model(model_adapter).build()
 
     logger.info("agent created", extra={"agent_name": agent.name})
 

--- a/examples/basic-chat/chat_simple.py
+++ b/examples/basic-chat/chat_simple.py
@@ -1,4 +1,4 @@
-"""Minimal chat example using SimpleChatAgent with inline configuration."""
+"""Minimal chat example using Builder with inline configuration."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from dare_framework.agent import SimpleChatAgent
+from dare_framework.builder import Builder
 from dare_framework.model import OpenAIModelAdapter
 
 MODEL = "qwen-7b"
@@ -52,10 +52,7 @@ async def main() -> None:
         endpoint=ENDPOINT,
         http_client_options=HTTP_CLIENT_OPTIONS,
     )
-    agent = SimpleChatAgent(
-        name="basic-chat",
-        model=model_adapter,
-    )
+    agent = Builder.simple_chat_agent_builder("basic-chat").with_model(model_adapter).build()
 
     while True:
         try:

--- a/examples/tool-management/README.md
+++ b/examples/tool-management/README.md
@@ -1,18 +1,19 @@
-# Tool Management Example
+# Tool Management Example (Builder-Based)
 
-This example demonstrates the tool management capabilities of `dare_framework`.
+This example demonstrates the tool management capabilities of `dare_framework` with builder-based assembly.
 
 ## Features Demonstrated
 
-1. **Gateway & Provider Setup** - Creating and connecting `DefaultToolGateway` with `NativeToolProvider`
-2. **Tool Registration** - Dynamically registering `NoopTool` and `EchoTool`
-3. **Capability Discovery** - Listing capabilities with trusted metadata
-4. **Health Checking** - Monitoring provider health status
-5. **Tool Invocation** - Invoking tools through the gateway with envelope boundaries
-6. **Envelope Restrictions** - Demonstrating capability allow-lists
-7. **Execution Control** - Using checkpoints, pause, and resume for HITL
-8. **LLM-Compatible Definitions** - Getting tool definitions for function-calling
-9. **Dynamic Management** - Register/unregister tools at runtime
+1. **Builder Assembly** - Building the agent shell while injecting a pre-wired gateway/provider
+2. **Gateway & Provider Setup** - Creating and connecting `DefaultToolGateway` with `NativeToolProvider`
+3. **Tool Registration** - Dynamically registering `NoopTool` and `EchoTool`
+4. **Capability Discovery** - Listing capabilities with trusted metadata
+5. **Health Checking** - Monitoring provider health status
+6. **Tool Invocation** - Invoking tools through the gateway with envelope boundaries
+7. **Envelope Restrictions** - Demonstrating capability allow-lists
+8. **Execution Control** - Using checkpoints, pause, and resume for HITL
+9. **LLM-Compatible Definitions** - Getting tool definitions for function-calling
+10. **Dynamic Management** - Register/unregister tools at runtime
 
 ## Running the Example
 
@@ -23,7 +24,7 @@ python examples/tool-management/main.py
 
 ## Real Model Tool-Chat Example
 
-This example mirrors the `examples/base_tool` tool chat flow and uses a real model adapter.
+This example mirrors the `examples/base_tool` tool chat flow and uses a real model adapter with builder wiring.
 
 ```bash
 python examples/tool-management/tool_chat.py

--- a/examples/tool-management/main.py
+++ b/examples/tool-management/main.py
@@ -1,4 +1,4 @@
-"""Tool Management Example.
+"""Tool Management Example (builder-based).
 
 This example demonstrates the tool management capabilities of dare_framework.
 Aligned with the v4 tool runtime configuration used in examples/base_tool.
@@ -16,6 +16,9 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from dare_framework.builder import Builder
+from dare_framework.infra.component import ComponentType
+from dare_framework.model import IModelAdapter
 from dare_framework.plan import Envelope
 from dare_framework.tool import (
     DefaultExecutionControl,
@@ -31,13 +34,28 @@ from dare_framework.tool import (
 WORKSPACE_ROOT = os.getenv("TOOL_WORKSPACE_ROOT", ".")
 
 
+# Builder requires a model adapter even when this example only exercises tools.
+class _NoopModelAdapter(IModelAdapter):
+    @property
+    def name(self) -> str:
+        return "noop-model-adapter"
+
+    @property
+    def component_type(self) -> ComponentType:
+        return ComponentType.MODEL_ADAPTER
+
+    async def generate(self, prompt, *, options=None):  # type: ignore[override]
+        raise RuntimeError("NoopModelAdapter is not intended for model generation.")
+
+
+
 async def main():
     """Demonstrate tool management features."""
-    
+
     print("=" * 60)
     print("DARE Framework v4 - Tool Management Example")
     print("=" * 60)
-    
+
     # 1. Create components
     print("\n[1] Creating components...")
     run_context = RunContextState(
@@ -50,15 +68,25 @@ async def main():
     execution_control = DefaultExecutionControl()
     tools = [NoopTool(), EchoTool()]
     provider = NativeToolProvider(tools=tools, context_factory=run_context.build)
-    
+    tool_provider = GatewayToolProvider(gateway)
+
+    # Build the agent shell while keeping tool wiring explicit for this demo.
+    _agent = (
+        Builder.simple_chat_agent_builder("tool-management")
+        .with_model(_NoopModelAdapter())
+        .with_tool_gateway(gateway)
+        .with_tool_provider(tool_provider)
+        .build()
+    )
+
     # 2. Register tools with the provider
     print("\n[2] Registering tools...")
     print(f"    Registered tools: noop, echo")
-    
+
     # 3. Register provider with gateway
     print("\n[3] Registering provider with gateway...")
     gateway.register_provider(provider)
-    
+
     # 4. List capabilities
     print("\n[4] Listing capabilities from gateway...")
     capabilities = await gateway.list_capabilities()
@@ -67,63 +95,62 @@ async def main():
         if cap.metadata:
             print(f"      risk_level: {cap.metadata.get('risk_level')}")
             print(f"      requires_approval: {cap.metadata.get('requires_approval')}")
-    
+
     # 5. Check provider health
     print("\n[5] Checking provider health...")
     health = await gateway.health_check()
     for provider_id, status in health.items():
         print(f"    {provider_id}: {status.value}")
-    
+
     # 6. Invoke tools through gateway
     print("\n[6] Invoking tools...")
-    
+
     # Create an envelope (execution boundary)
     envelope = Envelope(allowed_capability_ids=["tool:noop", "tool:echo"])
-    
+
     # Invoke noop tool
     print("\n    Invoking 'noop'...")
     result = await gateway.invoke("tool:noop", {}, envelope=envelope)
     print(f"    Result: success={result.success}, output={result.output}")
-    
+
     # Invoke echo tool
     print("\n    Invoking 'echo' with message='Hello, DARE!'...")
     result = await gateway.invoke("tool:echo", {"message": "Hello, DARE!"}, envelope=envelope)
     print(f"    Result: success={result.success}, output={result.output}")
-    
+
     # 7. Demonstrate envelope restrictions
     print("\n[7] Demonstrating envelope restrictions...")
     restricted_envelope = Envelope(allowed_capability_ids=["tool:noop"])  # echo not allowed
-    
+
     try:
         await gateway.invoke("tool:echo", {"message": "test"}, envelope=restricted_envelope)
     except PermissionError as e:
         print(f"    Expected error: {e}")
-    
+
     # 8. Demonstrate execution control
     print("\n[8] Demonstrating execution control...")
-    
+
     # Create a checkpoint
     checkpoint_id = await execution_control.checkpoint("demo", {"action": "test"})
     print(f"    Created checkpoint: {checkpoint_id[:8]}...")
-    
+
     # Pause execution
     pause_checkpoint = await execution_control.pause("User requested pause")
     print(f"    Paused with checkpoint: {pause_checkpoint[:8]}...")
     print(f"    Current signal: {execution_control.poll().value}")
-    
+
     # Resume execution
     await execution_control.resume(pause_checkpoint)
     print(f"    Resumed, signal: {execution_control.poll().value}")
-    
+
     # 9. Get LLM-compatible tool definitions
     print("\n[9] Getting LLM-compatible tool definitions...")
-    tool_provider = GatewayToolProvider(gateway)
     await tool_provider.refresh()
     tool_defs = tool_provider.list_tools()
     for tool_def in tool_defs:
         func = tool_def["function"]
         print(f"    - {func['name']}: {func['description'][:50]}...")
-    
+
     # 10. Dynamic tool management
     print("\n[10] Demonstrating dynamic tool management...")
     print(f"    Tools before unregister: {len(await provider.list())}")
@@ -131,7 +158,7 @@ async def main():
     print(f"    Tools after unregister 'noop': {len(await provider.list())}")
     provider.register_tool(NoopTool())
     print(f"    Tools after re-register: {len(await provider.list())}")
-    
+
     print("\n" + "=" * 60)
     print("Example completed successfully!")
     print("=" * 60)

--- a/examples/tool-management/tool_chat.py
+++ b/examples/tool-management/tool_chat.py
@@ -1,4 +1,4 @@
-"""Tool management chat example with a real model.
+"""Tool management chat example with a real model (builder-based).
 
 This mirrors the base_tool tool chat flow while keeping tool-management focus.
 """
@@ -11,17 +11,14 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any
 
 # Add project root to path for local development
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from dare_framework.context import Budget, Context, Message
-from dare_framework.memory import InMemorySTM
-from dare_framework.model import OpenAIModelAdapter, Prompt
-from dare_framework.plan import Envelope
+from dare_framework.builder import Builder
+from dare_framework.model import OpenAIModelAdapter
 from dare_framework.tool import (
     DefaultToolGateway,
     EditLineTool,
@@ -41,7 +38,6 @@ ENDPOINT = os.getenv("CHAT_ENDPOINT", "https://dashscope.aliyuncs.com/compatible
 HTTP_CLIENT_OPTIONS = {"trust_env": False, "proxy": None}
 LOG_LEVEL = os.getenv("CHAT_LOG_LEVEL", "INFO").upper()
 WORKSPACE_ROOT = os.getenv("TOOL_WORKSPACE_ROOT", ".")
-MAX_TOOL_ROUNDS = int(os.getenv("TOOL_MAX_ROUNDS", "3"))
 
 logger = logging.getLogger("tool-management-chat")
 
@@ -52,57 +48,7 @@ def _preview(text: str, limit: int = 200) -> str:
     return f"{text[:limit]}...<truncated>"
 
 
-def _serialize_messages(messages: list[Message]) -> list[dict[str, Any]]:
-    serialized: list[dict[str, Any]] = []
-    for msg in messages:
-        serialized.append(
-            {
-                "role": msg.role,
-                "content": msg.content,
-                "name": msg.name,
-                "metadata": dict(msg.metadata),
-            }
-        )
-    return serialized
-
-
-def _log_llm_request(prompt: Prompt) -> None:
-    request_body = {
-        "messages": _serialize_messages(prompt.messages),
-        "tools": prompt.tools,
-        "metadata": prompt.metadata,
-    }
-    logger.info("llm request body", extra={"request_body": request_body})
-    print(json.dumps({"llm_request": request_body}, indent=2, sort_keys=True, ensure_ascii=False))
-
-
-def _log_llm_response(response) -> None:
-    response_body = {
-        "content": response.content,
-        "tool_calls": response.tool_calls,
-        "usage": response.usage,
-        "metadata": response.metadata,
-    }
-    logger.info("llm response body", extra={"response_body": response_body})
-    print(json.dumps({"llm_response": response_body}, indent=2, sort_keys=True, ensure_ascii=False))
-
-
-def _log_messages(messages: list[Message], *, label: str) -> None:
-    logger.info(label, extra={"message_count": len(messages)})
-    for idx, msg in enumerate(messages, start=1):
-        logger.debug(
-            "message",
-            extra={
-                "index": idx,
-                "role": msg.role,
-                "name": msg.name,
-                "content": _preview(msg.content),
-                "metadata_keys": list(msg.metadata.keys()),
-            },
-        )
-
-
-def _log_tool_defs(tool_defs: list[dict[str, Any]]) -> None:
+def _log_tool_defs(tool_defs: list[dict[str, object]]) -> None:
     tool_names = []
     for tool in tool_defs:
         function = tool.get("function") if isinstance(tool, dict) else None
@@ -111,78 +57,18 @@ def _log_tool_defs(tool_defs: list[dict[str, Any]]) -> None:
     logger.info("tool defs loaded", extra={"tool_names": tool_names})
 
 
-async def _execute_tool_calls(
-    response,
-    *,
-    gateway: DefaultToolGateway,
-    context: Context,
-) -> bool:
-    tool_calls = response.tool_calls
-    if not tool_calls:
-        return False
-
-    context.stm_add(
-        Message(
-            role="assistant",
-            content=response.content or "",
-            metadata={"tool_calls": tool_calls},
-        )
-    )
-
-    for idx, call in enumerate(tool_calls, start=1):
-        tool_name = call.get("name")
-        if not tool_name:
-            logger.warning("tool call missing name", extra={"call": call})
-            continue
-        arguments = call.get("arguments") or {}
-        if not isinstance(arguments, dict):
-            arguments = {"raw": arguments}
-        call_id = call.get("id") or f"tool_call_{idx}"
-        capability_id = f"tool:{tool_name}"
-
-        logger.info(
-            "invoking tool",
-            extra={
-                "capability_id": capability_id,
-                "call_id": call_id,
-                "arguments": arguments,
-            },
-        )
+def _format_output(output: object | None) -> str:
+    if output is None:
+        return ""
+    if isinstance(output, dict):
+        content = output.get("content")
+        if content:
+            return str(content)
         try:
-            result = await gateway.invoke(
-                capability_id,
-                arguments,
-                envelope=Envelope(allowed_capability_ids=[capability_id]),
-            )
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("tool invocation failed")
-            result_payload = {"success": False, "error": str(exc)}
-        else:
-            result_payload = {
-                "success": result.success,
-                "output": result.output,
-                "error": result.error,
-            }
-            logger.info(
-                "tool invocation result",
-                extra={
-                    "capability_id": capability_id,
-                    "call_id": call_id,
-                    "success": result.success,
-                    "error": result.error,
-                },
-            )
-
-        context.stm_add(
-            Message(
-                role="tool",
-                name=call_id,
-                content=json.dumps(result_payload),
-                metadata={"tool_name": tool_name},
-            )
-        )
-
-    return True
+            return json.dumps(output, indent=2, sort_keys=True, ensure_ascii=False)
+        except TypeError:
+            return str(output)
+    return str(output)
 
 
 async def main() -> None:
@@ -233,18 +119,26 @@ async def main() -> None:
     ]
 
     gateway = DefaultToolGateway()
-    gateway.register_provider(NativeToolProvider(tools=tools, context_factory=run_context.build))
+    provider = NativeToolProvider(
+        tools=tools,
+        context_factory=run_context.build,
+        # Align capability ids with tool call names emitted by the model.
+        capability_prefix="",
+    )
+    gateway.register_provider(provider)
 
+    # Inject a tool provider so we can refresh tool defs asynchronously in this loop.
     tool_provider = GatewayToolProvider(gateway)
     await tool_provider.refresh()
     _log_tool_defs(tool_provider.list_tools())
 
-    context = Context(
-        id="tool-management-chat",
-        short_term_memory=InMemorySTM(),
-        budget=Budget(),
+    agent = (
+        Builder.five_layer_agent_builder("tool-management-chat")
+        .with_model(model_adapter)
+        .with_tool_gateway(gateway)
+        .with_tool_provider(tool_provider)
+        .build()
     )
-    context._tool_provider = tool_provider
 
     print("Tool Management Chat - Type your message (or /quit to exit):", flush=True)
     while True:
@@ -258,52 +152,23 @@ async def main() -> None:
         if prompt == "/quit":
             break
 
-        context.stm_add(Message(role="user", content=prompt))
-        assembled = context.assemble()
-        _log_messages(assembled.messages, label="assembled prompt")
-        logger.info("llm request", extra={"tools": len(assembled.tools)})
-        prompt_payload = Prompt(messages=assembled.messages, tools=assembled.tools, metadata=assembled.metadata)
-        _log_llm_request(prompt_payload)
-        response = await model_adapter.generate(prompt_payload)
-        logger.info(
-            "llm response",
-            extra={
-                "content": _preview(response.content),
-                "tool_call_count": len(response.tool_calls),
-                "usage": response.usage,
-            },
-        )
-        _log_llm_response(response)
+        logger.info("running prompt", extra={"prompt": _preview(prompt)})
+        try:
+            result = await agent.run(prompt)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("agent run failed")
+            print(f"[error] model call failed: {exc}", file=sys.stderr, flush=True)
+            continue
 
-        rounds = 0
-        while response.tool_calls and rounds < MAX_TOOL_ROUNDS:
-            rounds += 1
-            logger.info("tool calls detected", extra={"count": len(response.tool_calls), "round": rounds})
-            await _execute_tool_calls(response, gateway=gateway, context=context)
-            assembled = context.assemble()
-            _log_messages(assembled.messages, label="assembled prompt (post-tool)")
-            logger.info("llm request (post-tool)", extra={"tools": len(assembled.tools)})
-            prompt_payload = Prompt(messages=assembled.messages, tools=assembled.tools, metadata=assembled.metadata)
-            _log_llm_request(prompt_payload)
-            response = await model_adapter.generate(prompt_payload)
-            logger.info(
-                "llm response (post-tool)",
-                extra={
-                    "content": _preview(response.content),
-                    "tool_call_count": len(response.tool_calls),
-                    "usage": response.usage,
-                },
-            )
-            _log_llm_response(response)
+        content = _format_output(result.output)
+        if not content:
+            if result.errors:
+                print(f"[error] {', '.join(result.errors)}", file=sys.stderr, flush=True)
+            else:
+                print("No output returned.", flush=True)
+            continue
 
-        if response.tool_calls and rounds >= MAX_TOOL_ROUNDS:
-            logger.warning("tool rounds exhausted", extra={"max_rounds": MAX_TOOL_ROUNDS})
-
-        if response.content:
-            context.stm_add(Message(role="assistant", content=response.content))
-            print(response.content, flush=True)
-        else:
-            print("No output returned.", flush=True)
+        print(content, flush=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- switch tool chat examples to agent.run() with FiveLayerAgent ReAct loop

- keep tool wiring via builder while preserving gateway/provider demos

- update README descriptions to reflect builder-based flows