### PR TITLE
feat(plan): align plan module with v4 registry metadata

### DIFF
--- a/dare_framework/agent/_internal/five_layer.py
+++ b/dare_framework/agent/_internal/five_layer.py
@@ -30,6 +30,7 @@ from dare_framework.plan.types import (
     ValidatedPlan,
     VerifyResult,
 )
+from dare_framework.tool.types import CapabilityKind
 
 
 @dataclass
@@ -615,11 +616,14 @@ class FiveLayerAgent(BaseAgent):
                 }
 
             # Process tool calls
+            capability_index = await self._capability_index() if response.tool_calls else {}
             for tool_call in response.tool_calls:
                 name = tool_call.get("name", "")
+                capability_id = tool_call.get("capability_id") or name
+                descriptor = capability_index.get(capability_id) or capability_index.get(name)
 
-                # Check for plan tool
-                if name.startswith("plan:"):
+                # Check for plan tool (registry kind preferred, prefix supported)
+                if self._is_plan_tool_call(name, descriptor):
                     return {
                         "success": False,
                         "outputs": outputs,
@@ -631,7 +635,7 @@ class FiveLayerAgent(BaseAgent):
                 # Run tool loop
                 tool_result = await self._run_tool_loop(
                     ToolLoopRequest(
-                        capability_id=name,
+                        capability_id=capability_id,
                         params=tool_call.get("arguments", {}),
                     )
                 )
@@ -734,6 +738,31 @@ class FiveLayerAgent(BaseAgent):
     # =========================================================================
     # Helpers
     # =========================================================================
+
+    async def _capability_index(self) -> dict[str, Any]:
+        """Build a capability index from the trusted tool registry."""
+        if self._tool_gateway is None:
+            return {}
+        try:
+            capabilities = await self._tool_gateway.list_capabilities()
+        except Exception:
+            return {}
+        index: dict[str, Any] = {}
+        for capability in capabilities:
+            index[capability.id] = capability
+            index.setdefault(capability.name, capability)
+        return index
+
+    def _is_plan_tool_call(self, name: str, descriptor: Any | None) -> bool:
+        """Return True if the tool call should trigger a re-plan."""
+        if name.startswith("plan:"):
+            return True
+        if descriptor is None or descriptor.metadata is None:
+            return False
+        kind = descriptor.metadata.get("capability_kind")
+        if hasattr(kind, "value"):
+            kind = kind.value
+        return str(kind) == CapabilityKind.PLAN_TOOL.value
 
     def _poll_or_raise(self) -> None:
         """Poll execution control and raise if interrupted.

--- a/dare_framework/plan/_internal/__init__.py
+++ b/dare_framework/plan/_internal/__init__.py
@@ -1,4 +1,7 @@
-"""plan internal implementations (non-public)."""
+"""plan internal implementations (non-public).
+
+These helpers are optional and not wired by default; they exist as reference
+implementations or building blocks for custom composition.
+"""
 
 from __future__ import annotations
-

--- a/dare_framework/plan/_internal/registry_validator.py
+++ b/dare_framework/plan/_internal/registry_validator.py
@@ -1,0 +1,188 @@
+"""Validator that derives trusted plan metadata from the capability registry."""
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from dare_framework.infra.component import ComponentType
+from dare_framework.plan.interfaces import IValidator
+from dare_framework.plan.types import (
+    Envelope,
+    ProposedPlan,
+    ProposedStep,
+    RunResult,
+    ValidatedPlan,
+    ValidatedStep,
+    VerifyResult,
+)
+from dare_framework.security.types import RiskLevel
+from dare_framework.tool.types import CapabilityKind, CapabilityMetadata
+
+if TYPE_CHECKING:
+    from dare_framework.tool.kernel import IToolGateway
+    from dare_framework.tool.interfaces import IToolManager
+    from dare_framework.tool.types import CapabilityDescriptor
+
+
+class RegistryPlanValidator(IValidator):
+    """Validate plans using trusted capability registry metadata.
+
+    This validator:
+    - Confirms referenced capabilities exist in the registry
+    - Derives risk level and trusted metadata from registry entries
+    - Overrides any planner-provided security fields
+    """
+
+    def __init__(
+        self,
+        *,
+        tool_gateway: "IToolGateway | None" = None,
+        tool_manager: "IToolManager | None" = None,
+        name: str = "registry_plan_validator",
+    ) -> None:
+        if tool_gateway is None and tool_manager is None:
+            raise ValueError("RegistryPlanValidator requires a tool gateway or tool manager")
+        self._tool_gateway = tool_gateway
+        self._tool_manager = tool_manager
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def component_type(self) -> ComponentType:
+        return ComponentType.VALIDATOR
+
+    async def validate_plan(self, plan: ProposedPlan, ctx: Any) -> ValidatedPlan:
+        capability_index = await self._capability_index()
+        errors: list[str] = []
+        validated_steps: list[ValidatedStep] = []
+
+        for step in plan.steps:
+            validated = self._validate_step(step, capability_index, errors)
+            if validated is not None:
+                validated_steps.append(validated)
+
+        if errors:
+            return ValidatedPlan(
+                plan_description=plan.plan_description,
+                steps=[],
+                success=False,
+                errors=errors,
+            )
+
+        return ValidatedPlan(
+            plan_description=plan.plan_description,
+            steps=validated_steps,
+            success=True,
+            errors=[],
+        )
+
+    async def verify_milestone(self, result: RunResult, ctx: Any) -> VerifyResult:
+        if result.success:
+            return VerifyResult(success=True, errors=[], metadata={})
+        return VerifyResult(success=False, errors=list(result.errors), metadata={})
+
+    async def _capability_index(self) -> dict[str, "CapabilityDescriptor"]:
+        capabilities: list[CapabilityDescriptor] = []
+        if self._tool_gateway is not None:
+            capabilities = list(await self._tool_gateway.list_capabilities())
+        elif self._tool_manager is not None:
+            capabilities = list(self._tool_manager.list_capabilities())
+
+        index: dict[str, CapabilityDescriptor] = {}
+        for capability in capabilities:
+            index[capability.id] = capability
+            index.setdefault(capability.name, capability)
+        return index
+
+    def _validate_step(
+        self,
+        step: ProposedStep,
+        capability_index: dict[str, "CapabilityDescriptor"],
+        errors: list[str],
+    ) -> ValidatedStep | None:
+        if step.capability_id.startswith("plan:"):
+            risk_level = RiskLevel.READ_ONLY
+            metadata = {"capability_kind": CapabilityKind.PLAN_TOOL.value}
+            return ValidatedStep(
+                step_id=step.step_id,
+                capability_id=step.capability_id,
+                risk_level=risk_level,
+                params=dict(step.params),
+                description=step.description,
+                envelope=_derive_envelope(step.envelope, step.capability_id, risk_level),
+                metadata=metadata,
+            )
+
+        capability = capability_index.get(step.capability_id)
+        if capability is None:
+            errors.append(f"unknown capability: {step.capability_id}")
+            return None
+
+        metadata = _normalize_metadata(capability.metadata)
+        risk_level = _parse_risk_level(metadata.get("risk_level"))
+
+        return ValidatedStep(
+            step_id=step.step_id,
+            capability_id=step.capability_id,
+            risk_level=risk_level,
+            params=dict(step.params),
+            description=step.description,
+            envelope=_derive_envelope(step.envelope, step.capability_id, risk_level),
+            metadata=metadata,
+        )
+
+
+def _derive_envelope(
+    envelope: Envelope | None,
+    capability_id: str,
+    risk_level: RiskLevel,
+) -> Envelope:
+    if envelope is None:
+        return Envelope(
+            allowed_capability_ids=[capability_id],
+            risk_level=risk_level,
+        )
+
+    allowlist = envelope.allowed_capability_ids or [capability_id]
+    return Envelope(
+        allowed_capability_ids=list(allowlist),
+        budget=envelope.budget,
+        done_predicate=envelope.done_predicate,
+        risk_level=risk_level,
+    )
+
+
+def _normalize_metadata(metadata: CapabilityMetadata | None) -> dict[str, Any]:
+    if not metadata:
+        return {}
+    normalized: dict[str, Any] = {}
+    for key, value in dict(metadata).items():
+        normalized[key] = _normalize_value(value)
+    return normalized
+
+
+def _normalize_value(value: Any) -> Any:
+    if hasattr(value, "value"):
+        return value.value
+    if isinstance(value, dict):
+        return {k: _normalize_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_normalize_value(item) for item in value]
+    return value
+
+
+def _parse_risk_level(value: Any) -> RiskLevel:
+    if isinstance(value, RiskLevel):
+        return value
+    if isinstance(value, str):
+        try:
+            return RiskLevel(value)
+        except ValueError:
+            return RiskLevel.READ_ONLY
+    return RiskLevel.READ_ONLY
+
+
+__all__ = ["RegistryPlanValidator"]

--- a/dare_framework/plan/interfaces.py
+++ b/dare_framework/plan/interfaces.py
@@ -11,6 +11,8 @@ from dare_framework.plan.types import ProposedPlan, RunResult, ValidatedPlan, Ve
 
 
 class IPlanner(IComponent, Protocol):
+    """Plan generator that emits untrusted ProposedPlan output."""
+
     @property
     def component_type(self) -> Literal[ComponentType.PLANNER]:
         ...
@@ -19,6 +21,12 @@ class IPlanner(IComponent, Protocol):
 
 
 class IValidator(IComponent, Protocol):
+    """Plan and milestone validator that derives trusted plan state.
+
+    Implementations SHOULD derive security-critical fields (e.g., risk metadata)
+    from trusted registries rather than planner/model output.
+    """
+
     @property
     def component_type(self) -> Literal[ComponentType.VALIDATOR]:
         ...
@@ -29,6 +37,8 @@ class IValidator(IComponent, Protocol):
 
 
 class IRemediator(IComponent, Protocol):
+    """Produces reflection text to guide the next planning attempt."""
+
     @property
     def component_type(self) -> Literal[ComponentType.REMEDIATOR]:
         ...

--- a/dare_framework/plan/types.py
+++ b/dare_framework/plan/types.py
@@ -120,7 +120,10 @@ class ProposedStep:
 
 @dataclass(frozen=True)
 class ValidatedStep:
-    """Trusted step derived from registries and policy/trust checks."""
+    """Trusted step derived from registries and policy/trust checks.
+
+    Trusted registry fields beyond `risk_level` are stored in `metadata`.
+    """
 
     step_id: str
     capability_id: str
@@ -128,6 +131,7 @@ class ValidatedStep:
     params: dict[str, Any] = field(default_factory=dict)
     description: str = ""
     envelope: Envelope | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/examples/plan-loop/README.md
+++ b/examples/plan-loop/README.md
@@ -1,0 +1,40 @@
+# Example: Plan Loop (Five-Layer)
+
+This example demonstrates the canonical plan loop with a deterministic planner
+and a registry-backed validator. It runs fully offline while exercising the
+Plan -> Execute -> Tool flow using the built-in `EchoTool`.
+
+## What It Shows
+
+- **Plan Loop**: `EchoPlanner` emits a `ProposedPlan` with a tool step.
+- **Plan Validation**: `RegistryPlanValidator` derives trusted metadata from
+  the tool registry.
+- **Execute + Tool Loop**: a deterministic model adapter emits one tool call
+  then a final response to end the loop.
+
+## Run
+
+```bash
+python examples/plan-loop/plan_loop.py
+```
+
+You should see the generated plan, followed by the final run result.
+
+## Real Model Variant
+
+This mirrors the model configuration conventions used in
+`examples/base_tool/tool_chat3.4.py` and `examples/basic-chat/*`.
+
+```bash
+python examples/plan-loop/real_model_plan_loop.py
+```
+
+Environment variables:
+- `CHAT_MODEL` (default: `gpt-4o-mini`)
+- `CHAT_API_KEY`
+- `CHAT_ENDPOINT` (default: `https://api.openai.com/v1`)
+- `CHAT_LOG_LEVEL` (default: `INFO`)
+- `TOOL_WORKSPACE_ROOT` (default: `.`)
+- `PLAN_TASK` (default: `Read README.md and summarize the main purpose.`)
+- `PLAN_DEFAULT_READ_PATH` (default: `README.md`)
+- `PLAN_MAX_STEPS` (default: `3`)

--- a/examples/plan-loop/plan_loop.py
+++ b/examples/plan-loop/plan_loop.py
@@ -1,0 +1,161 @@
+"""Plan loop example using the canonical dare_framework runtime.
+
+This example wires a deterministic planner + registry validator into
+FiveLayerAgent and exercises the Plan -> Execute -> Tool path without
+external LLM dependencies.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+# Add project root to path for local development
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from dare_framework.agent import FiveLayerAgent
+from dare_framework.context import Message
+from dare_framework.infra.component import ComponentType
+from dare_framework.model.types import ModelResponse, Prompt
+from dare_framework.plan import ProposedPlan, ProposedStep
+from dare_framework.plan._internal.registry_validator import RegistryPlanValidator
+from dare_framework.tool import (
+    DefaultToolGateway,
+    EchoTool,
+    GatewayToolProvider,
+    NativeToolProvider,
+    RunContextState,
+)
+
+
+def _latest_user_message(messages: list[Message]) -> str:
+    for message in reversed(messages):
+        if message.role == "user":
+            return message.content
+    return ""
+
+
+class EchoPlanner:
+    """Deterministic planner that emits a single echo step."""
+
+    def __init__(self) -> None:
+        self._attempt = 0
+        self.last_plan: ProposedPlan | None = None
+
+    @property
+    def name(self) -> str:
+        return "echo_planner"
+
+    @property
+    def component_type(self) -> ComponentType:
+        return ComponentType.PLANNER
+
+    async def plan(self, ctx: Any) -> ProposedPlan:
+        self._attempt += 1
+        message = _latest_user_message(ctx.stm_get())
+        if not message:
+            message = "hello from planner"
+
+        plan = ProposedPlan(
+            plan_description="Echo the latest user message via the echo tool.",
+            steps=[
+                ProposedStep(
+                    step_id=f"step-{self._attempt}",
+                    capability_id="tool:echo",
+                    params={"message": message},
+                    description="Echo user input.",
+                )
+            ],
+            attempt=self._attempt,
+        )
+        self.last_plan = plan
+        return plan
+
+
+class DeterministicToolCallModel:
+    """Model adapter that issues one tool call, then final text.
+
+    This keeps the example fully offline while still exercising the Tool Loop.
+    """
+
+    def __init__(self) -> None:
+        self._calls = 0
+
+    @property
+    def name(self) -> str:
+        return "deterministic_tool_call_model"
+
+    @property
+    def component_type(self) -> ComponentType:
+        return ComponentType.MODEL_ADAPTER
+
+    async def generate(self, prompt: Prompt, *, options: Any = None) -> ModelResponse:
+        self._calls += 1
+        message = _latest_user_message(prompt.messages)
+
+        if self._calls == 1:
+            # First response triggers the tool call.
+            return ModelResponse(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "echo",
+                        "capability_id": "tool:echo",
+                        "arguments": {"message": message},
+                    }
+                ],
+            )
+
+        # Second response ends the Execute Loop.
+        return ModelResponse(
+            content=f"Done. Echo tool invoked with: {message}",
+            tool_calls=[],
+        )
+
+
+async def main() -> None:
+    run_context = RunContextState(config={"workspace_roots": ["."]})
+
+    gateway = DefaultToolGateway()
+    provider = NativeToolProvider(tools=[EchoTool()], context_factory=run_context.build)
+    gateway.register_provider(provider)
+
+    tool_provider = GatewayToolProvider(gateway)
+    await tool_provider.refresh()
+
+    planner = EchoPlanner()
+    validator = RegistryPlanValidator(tool_gateway=gateway)
+    model = DeterministicToolCallModel()
+
+    agent = FiveLayerAgent(
+        name="plan-loop-demo",
+        model=model,
+        tools=tool_provider,
+        tool_gateway=gateway,
+        planner=planner,
+        validator=validator,
+    )
+
+    result = await agent.run("Echo this message through the plan loop.")
+
+    print("Plan:")
+    if planner.last_plan is None:
+        print("  (no plan generated)")
+    else:
+        print(f"  description: {planner.last_plan.plan_description}")
+        for step in planner.last_plan.steps:
+            print(f"  - {step.step_id}: {step.capability_id} {step.params}")
+
+    print("\nRun Result:")
+    print(f"  success: {result.success}")
+    print(f"  output: {result.output}")
+    if result.errors:
+        print(f"  errors: {result.errors}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/plan-loop/real_model_plan_loop.py
+++ b/examples/plan-loop/real_model_plan_loop.py
@@ -1,0 +1,312 @@
+"""Plan loop example wired to a real model.
+
+References:
+- examples/base_tool/tool_chat3.4.py for model/env conventions
+- examples/plan-loop/plan_loop.py for deterministic plan loop shape
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Add project root to path for local development
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from dare_framework.agent import FiveLayerAgent
+from dare_framework.context import Message
+from dare_framework.infra.component import ComponentType
+from dare_framework.model import OpenAIModelAdapter, Prompt
+from dare_framework.plan import ProposedPlan, ProposedStep
+from dare_framework.plan._internal.registry_validator import RegistryPlanValidator
+from dare_framework.tool import (
+    DefaultToolGateway,
+    EchoTool,
+    GatewayToolProvider,
+    NativeToolProvider,
+    ReadFileTool,
+    RunContextState,
+    SearchCodeTool,
+)
+
+MODEL = os.getenv("CHAT_MODEL", "gpt-4o-mini")
+API_KEY = os.getenv("CHAT_API_KEY", "")
+ENDPOINT = os.getenv("CHAT_ENDPOINT", "https://api.openai.com/v1")
+HTTP_CLIENT_OPTIONS = {"trust_env": False, "proxy": None}
+LOG_LEVEL = os.getenv("CHAT_LOG_LEVEL", "INFO").upper()
+WORKSPACE_ROOT = os.getenv("TOOL_WORKSPACE_ROOT", ".")
+PLAN_TASK = os.getenv("PLAN_TASK", "Read README.md and summarize the main purpose.")
+DEFAULT_READ_PATH = os.getenv("PLAN_DEFAULT_READ_PATH", "README.md")
+MAX_STEPS = int(os.getenv("PLAN_MAX_STEPS", "3"))
+
+logger = logging.getLogger("plan-loop-real-model")
+
+
+def _latest_user_message(messages: list[Message]) -> str:
+    for message in reversed(messages):
+        if message.role == "user":
+            return message.content
+    return ""
+
+
+def _tool_catalog(tool_defs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    catalog: list[dict[str, Any]] = []
+    for tool in tool_defs:
+        function = tool.get("function") if isinstance(tool, dict) else None
+        if not isinstance(function, dict):
+            continue
+        name = function.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        catalog.append(
+            {
+                "name": name,
+                "description": function.get("description", ""),
+                "parameters": function.get("parameters", {}),
+            }
+        )
+    return catalog
+
+
+def _extract_json(text: str) -> dict[str, Any]:
+    """Extract a JSON object from model output.
+
+    This keeps parsing resilient to code fences or extra text.
+    """
+    if not text:
+        return {}
+
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        fence_end = cleaned.find("```", 3)
+        if fence_end != -1:
+            cleaned = cleaned[3:fence_end].strip()
+            if cleaned.startswith("json"):
+                cleaned = cleaned[4:].strip()
+
+    try:
+        data = json.loads(cleaned)
+        if isinstance(data, dict):
+            return data
+    except json.JSONDecodeError:
+        pass
+
+    start = cleaned.find("{")
+    end = cleaned.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        snippet = cleaned[start : end + 1]
+        try:
+            data = json.loads(snippet)
+            if isinstance(data, dict):
+                return data
+        except json.JSONDecodeError:
+            return {}
+
+    return {}
+
+
+class JsonPlanPlanner:
+    """Planner that asks a real model for a JSON plan."""
+
+    def __init__(
+        self,
+        model: OpenAIModelAdapter,
+        tool_defs: list[dict[str, Any]],
+        *,
+        default_read_path: str,
+        max_steps: int,
+    ) -> None:
+        self._model = model
+        self._tool_defs = list(tool_defs)
+        self._tool_names = {tool["name"] for tool in _tool_catalog(self._tool_defs)}
+        self._default_read_path = default_read_path
+        self._max_steps = max_steps
+        self.last_plan: ProposedPlan | None = None
+
+    @property
+    def name(self) -> str:
+        return "json_plan_planner"
+
+    @property
+    def component_type(self) -> ComponentType:
+        return ComponentType.PLANNER
+
+    async def plan(self, ctx: Any) -> ProposedPlan:
+        task = _latest_user_message(ctx.stm_get()) or "unknown task"
+        tool_catalog = _tool_catalog(self._tool_defs)
+        prompt = Prompt(
+            messages=[
+                Message(
+                    role="system",
+                    content=(
+                        "You are a planning module. Return JSON only (no markdown).\n"
+                        "Format: {\"plan_description\": str, \"steps\": "
+                        "[{\"tool\": str, \"arguments\": object, \"description\": str}]}\n"
+                        "Use only tools from the provided catalog and keep steps <= max_steps."
+                    ),
+                ),
+                Message(
+                    role="user",
+                    content=(
+                        f"Task: {task}\n"
+                        f"Default read path: {self._default_read_path}\n"
+                        f"max_steps: {self._max_steps}\n"
+                        f"Tool catalog: {json.dumps(tool_catalog, ensure_ascii=True)}"
+                    ),
+                ),
+            ],
+            tools=[],
+            metadata={"purpose": "plan"},
+        )
+
+        response = await self._model.generate(prompt)
+        data = _extract_json(response.content)
+        steps = self._steps_from_payload(data)
+
+        if not steps:
+            steps = self._fallback_steps(task)
+
+        plan = ProposedPlan(
+            plan_description=str(data.get("plan_description") or task),
+            steps=steps,
+        )
+        self.last_plan = plan
+        return plan
+
+    def _steps_from_payload(self, data: dict[str, Any]) -> list[ProposedStep]:
+        raw_steps = data.get("steps")
+        if not isinstance(raw_steps, list):
+            return []
+
+        steps: list[ProposedStep] = []
+        for idx, raw in enumerate(raw_steps[: self._max_steps], start=1):
+            if not isinstance(raw, dict):
+                continue
+            tool_name = raw.get("tool") or raw.get("tool_name") or raw.get("name")
+            if not isinstance(tool_name, str) or tool_name not in self._tool_names:
+                continue
+            params = raw.get("arguments") or raw.get("params") or raw.get("input") or {}
+            if not isinstance(params, dict):
+                params = {}
+            if tool_name == "read_file" and "path" not in params:
+                params["path"] = self._default_read_path
+
+            steps.append(
+                ProposedStep(
+                    step_id=f"step-{idx}",
+                    capability_id=f"tool:{tool_name}",
+                    params=params,
+                    description=str(raw.get("description") or ""),
+                )
+            )
+
+        return steps
+
+    def _fallback_steps(self, task: str) -> list[ProposedStep]:
+        if "read_file" in self._tool_names:
+            return [
+                ProposedStep(
+                    step_id="step-1",
+                    capability_id="tool:read_file",
+                    params={"path": self._default_read_path},
+                    description="Fallback to read the default file.",
+                )
+            ]
+        if "echo" in self._tool_names:
+            return [
+                ProposedStep(
+                    step_id="step-1",
+                    capability_id="tool:echo",
+                    params={"message": task},
+                    description="Fallback to echo the task.",
+                )
+            ]
+        return []
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=LOG_LEVEL,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )
+    logger.info(
+        "boot plan loop (real model)",
+        extra={
+            "model": MODEL,
+            "endpoint": ENDPOINT,
+            "api_key_set": bool(API_KEY),
+            "workspace_root": WORKSPACE_ROOT,
+        },
+    )
+
+    model = OpenAIModelAdapter(
+        model=MODEL,
+        api_key=API_KEY,
+        endpoint=ENDPOINT,
+        http_client_options=HTTP_CLIENT_OPTIONS,
+    )
+
+    run_context = RunContextState(
+        config={
+            "workspace_roots": [WORKSPACE_ROOT],
+            "tools": {
+                "read_file": {"max_bytes": 1_000_000},
+                "search_code": {
+                    "max_results": 50,
+                    "max_file_bytes": 1_000_000,
+                    "ignore_dirs": [".git", "node_modules", "__pycache__", ".venv", "venv"],
+                },
+            },
+        }
+    )
+
+    tools = [ReadFileTool(), SearchCodeTool(), EchoTool()]
+    gateway = DefaultToolGateway()
+    gateway.register_provider(NativeToolProvider(tools=tools, context_factory=run_context.build))
+
+    tool_provider = GatewayToolProvider(gateway)
+    await tool_provider.refresh()
+
+    planner = JsonPlanPlanner(
+        model,
+        tool_provider.list_tools(),
+        default_read_path=DEFAULT_READ_PATH,
+        max_steps=MAX_STEPS,
+    )
+    validator = RegistryPlanValidator(tool_gateway=gateway)
+
+    agent = FiveLayerAgent(
+        name="plan-loop-real-model",
+        model=model,
+        tools=tool_provider,
+        tool_gateway=gateway,
+        planner=planner,
+        validator=validator,
+    )
+
+    result = await agent.run(PLAN_TASK)
+
+    print("Plan:")
+    if planner.last_plan is None:
+        print("  (no plan generated)")
+    else:
+        print(f"  description: {planner.last_plan.plan_description}")
+        for step in planner.last_plan.steps:
+            print(f"  - {step.step_id}: {step.capability_id} {step.params}")
+
+    print("\nRun Result:")
+    print(f"  success: {result.success}")
+    print(f"  output: {result.output}")
+    if result.errors:
+        print(f"  errors: {result.errors}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/openspec/changes/archive/2026-01-27-update-plan-module-v4/design.md
+++ b/openspec/changes/archive/2026-01-27-update-plan-module-v4/design.md
@@ -1,0 +1,52 @@
+## 背景
+- V4 设计文档（`doc/design/Architecture.md`、`doc/design/Interfaces.md`）明确了五层循环、Plan Attempt Isolation、Plan Tool 语义与可信元数据派生规则。
+- 当前 `dare_framework/plan` 已具备基础类型与接口，但缺少一份明确的规格与边界说明，导致计划模块如何承载“可信/不可信分层”与“失败计划隔离”等核心语义仍不够清晰。
+
+## 目标 / 非目标
+### 目标
+- 以 V4 设计为准，补齐 plan 模块的数据模型与策略接口规范。
+- 明确 Proposed/Validated 分层与可信元数据派生的职责边界。
+- 明确 plan 与 tool/security/event 的交互边界，便于审计与复验。
+
+### 非目标
+- 不实现具体规划算法或 LLM 提示词策略。
+- 不改变五层循环的既有高层语义（由 `core-runtime` 规格负责）。
+- 不在本阶段引入新的外部依赖或持久化存储。
+
+## 关键决策
+1. **Plan 领域遵循 V4 目录约定**
+   - `types.py` 仅承载数据模型；`interfaces.py` 承载可插拔策略；`kernel.py` 作为稳定合同入口；默认实现放在 `_internal/`。
+
+2. **Proposed vs Validated 分层**
+   - Proposed 计划/步骤来源不可信（来自 planner），不得携带可信字段（如风险等级、审批要求、超时策略）。
+   - Validated 计划/步骤由 validator + 可信 registry 派生，至少携带 `risk_level`；其余可信字段（`requires_approval`、`timeout_seconds`、`capability_kind`、`is_work_unit`）统一存放在可信 `metadata` 中。
+
+3. **Envelope/ToolLoopRequest 作为执行边界**
+   - 计划步骤可携带 `Envelope`（允许能力、预算、DonePredicate、风险级别），执行层必须以 `ToolLoopRequest` 作为调用载体。
+
+4. **Plan Attempt Isolation 的数据承载**
+   - `ProposedPlan` 包含 `attempt` 与 `metadata`，用于记录尝试与诊断信息。
+   - 失败计划不进入外层状态，仅允许记录 attempt 元信息、错误与 remediation 产生的 reflection。
+
+5. **Plan Tool 语义对齐**
+   - 识别 Plan Tool 以 registry `capability_kind=plan_tool` 为主（兼容 `plan:` 前缀约定）。
+   - Execute 遇到 Plan Tool 需回到 Plan Loop，此语义由运行时实现，但 plan 模块需保留其能力类型信息。
+
+## 交互边界
+- **Tool Registry / ToolGateway**：Validator 在验证阶段基于可信 registry 派生 `risk_level` 与相关元数据，禁止使用 planner 输出的风险字段。
+- **Security Boundary**：Plan→Execute 阶段触发 `check_policy(action="execute_plan", ...)`；执行阶段对每个能力调用进行 `check_policy(action="invoke_capability", ...)`。
+- **Event Log**：计划尝试与验证结果必须形成结构化事件（`plan.attempt` / `plan.validated` / `plan.invalid`），并带有关联标识（task/session/milestone）。
+
+## 风险 / 权衡
+- **字段粒度**：在 `ValidatedStep` 中强制加入全部可信元数据会增加迁移成本；以结构化字段 + `metadata` 的折中方式降低破坏性变更。
+- **数据结构扩展**：本次不新增独立 `PlanAttempt` 结构体，计划尝试信息通过 `ProposedPlan.attempt/metadata` 与事件日志承载。
+- **行为 vs 数据**：Plan Attempt Isolation 是运行时行为，但需要 plan 类型提供足够的可审计字段以支持验证与回放。
+
+## 迁移计划
+1. 对齐 plan 类型与接口（Proposed/Validated 分层、Envelope、VerifyResult/RunResult 等）。
+2. 补齐 validator 的派生语义与事件日志字段（实现阶段）。
+3. 对齐五层循环中的计划隔离与 Plan Tool 处理（实现阶段）。
+4. 添加覆盖计划分层、验证失败隔离、计划工具回退的测试与验证。
+
+## 开放问题
+暂无（范围限定为 `dare_framework`；可信元数据统一放入 `metadata`；不新增 `PlanAttempt` 结构体）。

--- a/openspec/changes/archive/2026-01-27-update-plan-module-v4/proposal.md
+++ b/openspec/changes/archive/2026-01-27-update-plan-module-v4/proposal.md
@@ -1,0 +1,15 @@
+# 变更：对齐 V4 设计的 plan 模块
+
+## 为什么
+当前 `dare_framework/plan` 已有类型与接口，但缺少一份明确的 V4 设计对齐规范（尤其是“Proposed vs Validated”、“可信元数据派生”、“Plan Attempt Isolation”等核心约束的落地说明）。为了确保规划闭环在可信边界、审计与可扩展性上与 V4 设计一致，需要为 plan 模块补齐规格与设计文档，并明确后续实现的范围与边界。
+
+## 变更内容
+- 为 plan 模块新增一份 V4 对齐的规格说明（plan-module spec）。
+- 明确 plan 领域的数据模型边界：Proposed/Validated 分层、Envelope/ToolLoopRequest 的职责、验证与补救的返回语义。
+- 记录与 V4 五层循环一致的计划尝试隔离要求及其在 plan 模块中的数据承载方式。
+- 在设计文档中说明与 tool registry / security boundary / event log 的交互边界与可信派生规则。
+ - 变更范围仅覆盖 `dare_framework`，不涉及 `dare_framework3_4`。
+
+## 影响
+- 影响规格：新增 `plan-module` 规格（与 `core-runtime`、`interface-layer`、`define-core-models` 交叉引用）。
+- 影响代码（实现阶段）：`dare_framework/plan/*`、`dare_framework/agent/_internal/five_layer.py`、可能涉及 `dare_framework/security/*` 与 `dare_framework/tool/*` 的对齐点。

--- a/openspec/changes/archive/2026-01-27-update-plan-module-v4/specs/plan-module/spec.md
+++ b/openspec/changes/archive/2026-01-27-update-plan-module-v4/specs/plan-module/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+### Requirement: 计划模型分层（Proposed vs Validated）
+计划模块 SHALL 提供明确的 Proposed/Validated 类型分层：
+- Proposed 计划与步骤来自 planner，视为不可信输入。
+- Validated 计划与步骤由 validator 基于可信 registry 派生，至少包含可信 `risk_level`；其余可信字段统一承载在可信 `metadata` 中，且不与 Proposed 类型混用或别名化。
+
+#### Scenario: 读取计划类型分层
+- **WHEN** 贡献者查看 plan 模型
+- **THEN** ProposedPlan/ProposedStep 与 ValidatedPlan/ValidatedStep 为独立类型，且 ValidatedStep 明确携带可信字段
+
+### Requirement: 计划尝试的可审计信息承载
+计划模块 SHALL 提供足够字段以记录计划尝试：
+- ProposedPlan 包含 `attempt` 与 `metadata` 以支持 `plan.attempt` 事件记录。
+- ValidatedPlan 包含 `success` 与 `errors` 以支持 `plan.validated/plan.invalid` 事件记录。
+
+#### Scenario: 无效计划仅记录尝试元信息
+- **WHEN** validator 返回 `success=false`
+- **THEN** 运行时可记录 attempt 元信息与错误，并且无效计划步骤不会作为外层状态持久化
+
+### Requirement: 计划策略接口语义
+计划模块 SHALL 定义 `IPlanner`、`IValidator`、`IRemediator` 及其 manager 接口，并满足如下语义：
+- `IPlanner.plan(ctx)` 返回 `ProposedPlan`。
+- `IValidator.validate_plan(plan, ctx)` 返回 `ValidatedPlan`，且通过 `success/errors` 表示是否通过验证。
+- `IValidator.verify_milestone(result, ctx)` 返回 `VerifyResult`。
+- `IRemediator.remediate(verify_result, ctx)` 返回可写入反思的文本。
+
+#### Scenario: Planner 返回 ProposedPlan
+- **WHEN** 调用 `IPlanner.plan(ctx)`
+- **THEN** 返回包含 `plan_description` 与有序 `steps` 的 ProposedPlan
+
+### Requirement: 计划步骤与 Tool Loop 执行边界
+计划模块 SHALL 提供 `Envelope`、`DonePredicate`、`ToolLoopRequest` 模型，以支撑 Tool Loop 的执行边界：
+- `Envelope` 至少包含 `allowed_capability_ids`、`budget`、`done_predicate`、`risk_level`。
+- `ToolLoopRequest` 由 `capability_id + params + envelope` 组成。
+- `ValidatedStep` 可在可信 `metadata` 中携带由 registry 派生的 `capability_kind` 等字段，以支持 Plan Tool 识别。
+
+#### Scenario: ToolLoopRequest 受 Envelope 约束
+- **GIVEN** 一个包含 `allowed_capability_ids` 的 Envelope
+- **WHEN** 从 ValidatedStep 生成 ToolLoopRequest
+- **THEN** 调用仅允许发生在该 allowlist 范围内

--- a/openspec/changes/archive/2026-01-27-update-plan-module-v4/tasks.md
+++ b/openspec/changes/archive/2026-01-27-update-plan-module-v4/tasks.md
@@ -1,0 +1,7 @@
+## 1. 实现
+- [ ] 1.1 对齐 plan 数据模型（Proposed/Validated、Envelope/ToolLoopRequest、可信 metadata 承载）并更新公开导出。
+- [ ] 1.2 补齐 plan 策略接口语义（IPlanner/IValidator/IRemediator 及 manager）与必要注释。
+- [ ] 1.3 在五层循环中落实 Plan Attempt Isolation 与 Plan Tool 回退行为（仅持久化 attempt 元信息与 reflection）。
+- [ ] 1.4 Validator 基于可信 registry 派生风险/审批元数据并写入 ValidatedStep。
+- [ ] 1.5 增补测试：计划分层、无效计划不外泄、Plan Tool 触发回到 Plan Loop。
+- [ ] 1.6 验证：运行相关 pytest 目标，并执行 `openspec validate update-plan-module-v4 --strict`。

--- a/openspec/specs/plan-module/spec.md
+++ b/openspec/specs/plan-module/spec.md
@@ -1,0 +1,45 @@
+# plan-module Specification
+
+## Purpose
+TBD - created by archiving change update-plan-module-v4. Update Purpose after archive.
+## Requirements
+### Requirement: 计划模型分层（Proposed vs Validated）
+计划模块 SHALL 提供明确的 Proposed/Validated 类型分层：
+- Proposed 计划与步骤来自 planner，视为不可信输入。
+- Validated 计划与步骤由 validator 基于可信 registry 派生，至少包含可信 `risk_level`；其余可信字段统一承载在可信 `metadata` 中，且不与 Proposed 类型混用或别名化。
+
+#### Scenario: 读取计划类型分层
+- **WHEN** 贡献者查看 plan 模型
+- **THEN** ProposedPlan/ProposedStep 与 ValidatedPlan/ValidatedStep 为独立类型，且 ValidatedStep 明确携带可信字段
+
+### Requirement: 计划尝试的可审计信息承载
+计划模块 SHALL 提供足够字段以记录计划尝试：
+- ProposedPlan 包含 `attempt` 与 `metadata` 以支持 `plan.attempt` 事件记录。
+- ValidatedPlan 包含 `success` 与 `errors` 以支持 `plan.validated/plan.invalid` 事件记录。
+
+#### Scenario: 无效计划仅记录尝试元信息
+- **WHEN** validator 返回 `success=false`
+- **THEN** 运行时可记录 attempt 元信息与错误，并且无效计划步骤不会作为外层状态持久化
+
+### Requirement: 计划策略接口语义
+计划模块 SHALL 定义 `IPlanner`、`IValidator`、`IRemediator` 及其 manager 接口，并满足如下语义：
+- `IPlanner.plan(ctx)` 返回 `ProposedPlan`。
+- `IValidator.validate_plan(plan, ctx)` 返回 `ValidatedPlan`，且通过 `success/errors` 表示是否通过验证。
+- `IValidator.verify_milestone(result, ctx)` 返回 `VerifyResult`。
+- `IRemediator.remediate(verify_result, ctx)` 返回可写入反思的文本。
+
+#### Scenario: Planner 返回 ProposedPlan
+- **WHEN** 调用 `IPlanner.plan(ctx)`
+- **THEN** 返回包含 `plan_description` 与有序 `steps` 的 ProposedPlan
+
+### Requirement: 计划步骤与 Tool Loop 执行边界
+计划模块 SHALL 提供 `Envelope`、`DonePredicate`、`ToolLoopRequest` 模型，以支撑 Tool Loop 的执行边界：
+- `Envelope` 至少包含 `allowed_capability_ids`、`budget`、`done_predicate`、`risk_level`。
+- `ToolLoopRequest` 由 `capability_id + params + envelope` 组成。
+- `ValidatedStep` 可在可信 `metadata` 中携带由 registry 派生的 `capability_kind` 等字段，以支持 Plan Tool 识别。
+
+#### Scenario: ToolLoopRequest 受 Envelope 约束
+- **GIVEN** 一个包含 `allowed_capability_ids` 的 Envelope
+- **WHEN** 从 ValidatedStep 生成 ToolLoopRequest
+- **THEN** 调用仅允许发生在该 allowlist 范围内
+

--- a/tests/unit/test_five_layer_agent.py
+++ b/tests/unit/test_five_layer_agent.py
@@ -11,6 +11,7 @@ import pytest
 from dare_framework.agent import FiveLayerAgent
 from dare_framework.context import Budget, Context, Message
 from dare_framework.model.types import ModelInput, ModelResponse
+from dare_framework.tool.types import CapabilityDescriptor, CapabilityKind, CapabilityType
 
 
 # =============================================================================
@@ -84,8 +85,12 @@ class MockValidator:
 class MockToolGateway:
     """Mock tool gateway for testing."""
 
-    def __init__(self) -> None:
+    def __init__(self, capabilities: list[Any] | None = None) -> None:
         self.invoke_calls = []
+        self._capabilities = list(capabilities or [])
+
+    async def list_capabilities(self) -> list[Any]:
+        return list(self._capabilities)
 
     async def invoke(self, capability_id: str, params: dict[str, Any], *, envelope: Any) -> Any:
         self.invoke_calls.append((capability_id, params, envelope))
@@ -323,6 +328,44 @@ class TestFiveLayerMode:
         await agent.run("Complete a milestone")
 
         assert len(validator.verify_calls) >= 1
+
+    @pytest.mark.asyncio
+    async def test_plan_tool_detected_via_registry_metadata(self) -> None:
+        """Plan tool detection prefers trusted registry metadata over name prefix."""
+        plan_tool = CapabilityDescriptor(
+            id="tool:replan",
+            type=CapabilityType.TOOL,
+            name="replan",
+            description="Trigger replanning.",
+            input_schema={"type": "object", "properties": {}},
+            metadata={"capability_kind": CapabilityKind.PLAN_TOOL},
+        )
+        model = MockModelAdapter(
+            [
+                ModelResponse(
+                    content="Need to replan.",
+                    tool_calls=[{"name": "replan", "arguments": {}}],
+                ),
+                ModelResponse(content="Done.", tool_calls=[]),
+            ]
+        )
+        planner = MockPlanner()
+        validator = MockValidator()
+        tool_gateway = MockToolGateway([plan_tool])
+        agent = FiveLayerAgent(
+            name="five-layer-agent",
+            model=model,
+            planner=planner,
+            validator=validator,
+            tool_gateway=tool_gateway,
+        )
+
+        result = await agent.run("Handle plan tool")
+
+        assert result.success is True
+        state = agent._session_state.current_milestone_state
+        assert state is not None
+        assert any("plan tool encountered" in text for text in state.reflections)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_registry_plan_validator.py
+++ b/tests/unit/test_registry_plan_validator.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dare_framework.plan._internal.registry_validator import RegistryPlanValidator
+from dare_framework.plan.types import Envelope, ProposedPlan, ProposedStep
+from dare_framework.security.types import RiskLevel
+from dare_framework.tool._internal.managers.tool_manager import ToolManager
+from dare_framework.tool.interfaces import ITool
+from dare_framework.tool.types import CapabilityKind, ToolResult, ToolType
+from dare_framework.infra.component import ComponentType
+
+
+class DummyTool(ITool):
+    def __init__(self, name: str, *, risk_level: str = "read_only") -> None:
+        self._name = name
+        self._risk_level = risk_level
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def component_type(self) -> ComponentType:
+        return ComponentType.TOOL
+
+    @property
+    def description(self) -> str:
+        return "dummy"
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {"type": "object", "properties": {}}
+
+    @property
+    def output_schema(self) -> dict[str, Any] | None:
+        return None
+
+    @property
+    def tool_type(self) -> ToolType:
+        return ToolType.ATOMIC
+
+    @property
+    def risk_level(self) -> str:
+        return self._risk_level
+
+    @property
+    def requires_approval(self) -> bool:
+        return True
+
+    @property
+    def timeout_seconds(self) -> int:
+        return 30
+
+    @property
+    def is_work_unit(self) -> bool:
+        return False
+
+    @property
+    def capability_kind(self) -> CapabilityKind:
+        return CapabilityKind.TOOL
+
+    async def execute(self, input: dict[str, Any], context: Any) -> ToolResult:
+        return ToolResult(success=True, output=input)
+
+
+@pytest.mark.asyncio
+async def test_registry_validator_derives_trusted_metadata() -> None:
+    tool = DummyTool("write_file", risk_level="idempotent_write")
+    manager = ToolManager()
+    descriptor = manager.register_tool(tool)
+    validator = RegistryPlanValidator(tool_manager=manager)
+
+    plan = ProposedPlan(
+        plan_description="plan",
+        steps=[
+            ProposedStep(
+                step_id="s1",
+                capability_id=descriptor.id,
+                params={"path": "x"},
+                envelope=Envelope(risk_level=RiskLevel.NON_IDEMPOTENT_EFFECT),
+            )
+        ],
+    )
+
+    validated = await validator.validate_plan(plan, {})
+
+    assert validated.success is True
+    assert validated.steps[0].risk_level == RiskLevel.IDEMPOTENT_WRITE
+    assert validated.steps[0].metadata["capability_kind"] == CapabilityKind.TOOL.value
+    assert validated.steps[0].envelope is not None
+    assert validated.steps[0].envelope.risk_level == RiskLevel.IDEMPOTENT_WRITE
+
+
+@pytest.mark.asyncio
+async def test_registry_validator_flags_unknown_capability() -> None:
+    validator = RegistryPlanValidator(tool_manager=ToolManager())
+
+    plan = ProposedPlan(
+        plan_description="plan",
+        steps=[
+            ProposedStep(
+                step_id="s1",
+                capability_id="tool:missing",
+                params={},
+            )
+        ],
+    )
+
+    validated = await validator.validate_plan(plan, {})
+
+    assert validated.success is False
+    assert "unknown capability" in validated.errors[0]
+
+
+@pytest.mark.asyncio
+async def test_registry_validator_handles_plan_tool_prefix() -> None:
+    validator = RegistryPlanValidator(tool_manager=ToolManager())
+
+    plan = ProposedPlan(
+        plan_description="plan",
+        steps=[
+            ProposedStep(
+                step_id="s1",
+                capability_id="plan:replan",
+                params={},
+            )
+        ],
+    )
+
+    validated = await validator.validate_plan(plan, {})
+
+    assert validated.success is True
+    assert validated.steps[0].risk_level == RiskLevel.READ_ONLY
+    assert validated.steps[0].metadata["capability_kind"] == CapabilityKind.PLAN_TOOL.value


### PR DESCRIPTION
- add ValidatedStep metadata and a registry-backed plan validator to derive trusted fields\n- detect plan tools via capability metadata (with prefix fallback) and honor capability_id\n- add unit coverage for registry validation and plan-tool detection\n- archive the plan-module spec change and publish spec in openspec