### PR TITLE
Align plan tooling with registry and done-predicate runtime

### DIFF
--- a/dare_framework/agent/_internal/five_layer.py
+++ b/dare_framework/agent/_internal/five_layer.py
@@ -23,6 +23,8 @@ from dare_framework.agent.interfaces import IAgentOrchestration
 from dare_framework.context import AssembledContext, Context, Message
 from dare_framework.model import IModelAdapter, ModelInput
 from dare_framework.plan.types import (
+    DonePredicate,
+    Envelope,
     Milestone,
     RunResult,
     Task,
@@ -676,42 +678,69 @@ class FiveLayerAgent(BaseAgent):
                 "error": "no tool gateway configured",
             }
 
-        await self._log_event("tool.invoke", {
-            "capability_id": request.capability_id,
-        })
+        done_predicate = request.envelope.done_predicate
+        max_calls = self._tool_loop_max_calls(request.envelope)
+        attempts = 0
 
-        try:
-            result = await self._tool_gateway.invoke(
-                request.capability_id,
-                request.params,
-                envelope=request.envelope,
-            )
+        while True:
+            attempts += 1
+            self._context.budget_check()
+            self._context.budget_use("tool_calls", 1)
 
-            await self._log_event("tool.result", {
+            await self._log_event("tool.invoke", {
                 "capability_id": request.capability_id,
-                "success": True,
+                "attempt": attempts,
             })
 
-            # Collect evidence
-            milestone_state = self._session_state.current_milestone_state
-            if milestone_state and hasattr(result, "evidence"):
-                for evidence in result.evidence:
-                    milestone_state.add_evidence(evidence)
+            try:
+                result = await self._tool_gateway.invoke(
+                    request.capability_id,
+                    request.params,
+                    envelope=request.envelope,
+                )
 
-            return {
-                "success": True,
-                "result": result,
-            }
+                await self._log_event("tool.result", {
+                    "capability_id": request.capability_id,
+                    "success": True,
+                    "attempt": attempts,
+                })
 
-        except Exception as e:
-            await self._log_event("tool.error", {
-                "capability_id": request.capability_id,
-                "error": str(e),
-            })
-            return {
-                "success": False,
-                "error": str(e),
-            }
+                if hasattr(result, "success") and not result.success:
+                    return {
+                        "success": False,
+                        "error": result.error or "tool failed",
+                        "result": result,
+                    }
+
+                # Collect evidence
+                milestone_state = self._session_state.current_milestone_state
+                if milestone_state and hasattr(result, "evidence"):
+                    for evidence in result.evidence:
+                        milestone_state.add_evidence(evidence)
+
+                if done_predicate is None or _done_predicate_satisfied(done_predicate, result):
+                    return {
+                        "success": True,
+                        "result": result,
+                    }
+
+                if max_calls is not None and attempts >= max_calls:
+                    return {
+                        "success": False,
+                        "error": "done predicate not satisfied before budget exhausted",
+                        "result": result,
+                    }
+
+            except Exception as e:
+                await self._log_event("tool.error", {
+                    "capability_id": request.capability_id,
+                    "error": str(e),
+                    "attempt": attempts,
+                })
+                return {
+                    "success": False,
+                    "error": str(e),
+                }
 
     # =========================================================================
     # Verify
@@ -764,6 +793,13 @@ class FiveLayerAgent(BaseAgent):
             kind = kind.value
         return str(kind) == CapabilityKind.PLAN_TOOL.value
 
+    def _tool_loop_max_calls(self, envelope: Envelope) -> int | None:
+        if envelope.budget.max_tool_calls is not None:
+            return envelope.budget.max_tool_calls
+        if self._context.budget.max_tool_calls is not None:
+            return self._context.budget.max_tool_calls
+        return self._max_tool_iterations
+
     def _poll_or_raise(self) -> None:
         """Poll execution control and raise if interrupted.
 
@@ -814,3 +850,16 @@ class FiveLayerAgent(BaseAgent):
 
 
 __all__ = ["FiveLayerAgent"]
+
+
+def _done_predicate_satisfied(done_predicate: DonePredicate, result: Any) -> bool:
+    required_keys = list(done_predicate.required_keys or [])
+    if not required_keys:
+        return True
+    output = getattr(result, "output", None)
+    if not isinstance(output, dict):
+        return False
+    for key in required_keys:
+        if key not in output:
+            return False
+    return True

--- a/dare_framework/plan/_internal/registry_validator.py
+++ b/dare_framework/plan/_internal/registry_validator.py
@@ -55,12 +55,12 @@ class RegistryPlanValidator(IValidator):
         return ComponentType.VALIDATOR
 
     async def validate_plan(self, plan: ProposedPlan, ctx: Any) -> ValidatedPlan:
-        capability_index = await self._capability_index()
+        capability_index, alias_index = await self._capability_index()
         errors: list[str] = []
         validated_steps: list[ValidatedStep] = []
 
         for step in plan.steps:
-            validated = self._validate_step(step, capability_index, errors)
+            validated = self._validate_step(step, capability_index, alias_index, errors)
             if validated is not None:
                 validated_steps.append(validated)
 
@@ -84,23 +84,32 @@ class RegistryPlanValidator(IValidator):
             return VerifyResult(success=True, errors=[], metadata={})
         return VerifyResult(success=False, errors=list(result.errors), metadata={})
 
-    async def _capability_index(self) -> dict[str, "CapabilityDescriptor"]:
+    async def _capability_index(
+        self,
+    ) -> tuple[dict[str, "CapabilityDescriptor"], dict[str, list["CapabilityDescriptor"]]]:
         capabilities: list[CapabilityDescriptor] = []
         if self._tool_gateway is not None:
             capabilities = list(await self._tool_gateway.list_capabilities())
         elif self._tool_manager is not None:
-            capabilities = list(self._tool_manager.list_capabilities())
+            capabilities = list(await self._tool_manager.list_capabilities())
 
-        index: dict[str, CapabilityDescriptor] = {}
+        by_id: dict[str, CapabilityDescriptor] = {}
+        by_alias: dict[str, list[CapabilityDescriptor]] = {}
         for capability in capabilities:
-            index[capability.id] = capability
-            index.setdefault(capability.name, capability)
-        return index
+            by_id[capability.id] = capability
+            _add_alias(by_alias, capability.name, capability)
+            display_name = None
+            if capability.metadata:
+                display_name = capability.metadata.get("display_name")
+            if isinstance(display_name, str) and display_name:
+                _add_alias(by_alias, display_name, capability)
+        return by_id, by_alias
 
     def _validate_step(
         self,
         step: ProposedStep,
         capability_index: dict[str, "CapabilityDescriptor"],
+        alias_index: dict[str, list["CapabilityDescriptor"]],
         errors: list[str],
     ) -> ValidatedStep | None:
         if step.capability_id.startswith("plan:"):
@@ -116,9 +125,8 @@ class RegistryPlanValidator(IValidator):
                 metadata=metadata,
             )
 
-        capability = capability_index.get(step.capability_id)
+        resolved_id, capability = _resolve_capability(step.capability_id, capability_index, alias_index, errors)
         if capability is None:
-            errors.append(f"unknown capability: {step.capability_id}")
             return None
 
         metadata = _normalize_metadata(capability.metadata)
@@ -126,11 +134,11 @@ class RegistryPlanValidator(IValidator):
 
         return ValidatedStep(
             step_id=step.step_id,
-            capability_id=step.capability_id,
+            capability_id=resolved_id,
             risk_level=risk_level,
             params=dict(step.params),
             description=step.description,
-            envelope=_derive_envelope(step.envelope, step.capability_id, risk_level),
+            envelope=_derive_envelope(step.envelope, resolved_id, risk_level),
             metadata=metadata,
         )
 
@@ -153,6 +161,37 @@ def _derive_envelope(
         done_predicate=envelope.done_predicate,
         risk_level=risk_level,
     )
+
+
+def _add_alias(
+    alias_index: dict[str, list["CapabilityDescriptor"]],
+    alias: str,
+    capability: "CapabilityDescriptor",
+) -> None:
+    if not alias:
+        return
+    alias_index.setdefault(alias, []).append(capability)
+
+
+def _resolve_capability(
+    raw_id: str,
+    capability_index: dict[str, "CapabilityDescriptor"],
+    alias_index: dict[str, list["CapabilityDescriptor"]],
+    errors: list[str],
+) -> tuple[str, "CapabilityDescriptor | None"]:
+    capability = capability_index.get(raw_id)
+    if capability is not None:
+        return capability.id, capability
+    matches = alias_index.get(raw_id, [])
+    if not matches:
+        errors.append(f"unknown capability: {raw_id}")
+        return raw_id, None
+    if len(matches) > 1:
+        match_ids = sorted({match.id for match in matches})
+        errors.append(f"ambiguous capability name '{raw_id}': matches {match_ids}")
+        return raw_id, None
+    resolved = matches[0]
+    return resolved.id, resolved
 
 
 def _normalize_metadata(metadata: CapabilityMetadata | None) -> dict[str, Any]:

--- a/examples/plan-loop/plan_loop.py
+++ b/examples/plan-loop/plan_loop.py
@@ -20,15 +20,13 @@ if str(PROJECT_ROOT) not in sys.path:
 from dare_framework.agent import FiveLayerAgent
 from dare_framework.context import Message
 from dare_framework.infra.component import ComponentType
-from dare_framework.model.types import ModelResponse, Prompt
+from dare_framework.model.types import ModelInput, ModelResponse
 from dare_framework.plan import ProposedPlan, ProposedStep
 from dare_framework.plan._internal.registry_validator import RegistryPlanValidator
 from dare_framework.tool import (
-    DefaultToolGateway,
     EchoTool,
-    GatewayToolProvider,
-    NativeToolProvider,
     RunContextState,
+    ToolManager,
 )
 
 
@@ -42,9 +40,10 @@ def _latest_user_message(messages: list[Message]) -> str:
 class EchoPlanner:
     """Deterministic planner that emits a single echo step."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, capability_id: str) -> None:
         self._attempt = 0
         self.last_plan: ProposedPlan | None = None
+        self._capability_id = capability_id
 
     @property
     def name(self) -> str:
@@ -65,7 +64,7 @@ class EchoPlanner:
             steps=[
                 ProposedStep(
                     step_id=f"step-{self._attempt}",
-                    capability_id="tool:echo",
+                    capability_id=self._capability_id,
                     params={"message": message},
                     description="Echo user input.",
                 )
@@ -82,8 +81,9 @@ class DeterministicToolCallModel:
     This keeps the example fully offline while still exercising the Tool Loop.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, capability_id: str) -> None:
         self._calls = 0
+        self._capability_id = capability_id
 
     @property
     def name(self) -> str:
@@ -93,9 +93,9 @@ class DeterministicToolCallModel:
     def component_type(self) -> ComponentType:
         return ComponentType.MODEL_ADAPTER
 
-    async def generate(self, prompt: Prompt, *, options: Any = None) -> ModelResponse:
+    async def generate(self, model_input: ModelInput, *, options: Any = None) -> ModelResponse:
         self._calls += 1
-        message = _latest_user_message(prompt.messages)
+        message = _latest_user_message(model_input.messages)
 
         if self._calls == 1:
             # First response triggers the tool call.
@@ -103,8 +103,8 @@ class DeterministicToolCallModel:
                 content="",
                 tool_calls=[
                     {
-                        "name": "echo",
-                        "capability_id": "tool:echo",
+                        "name": self._capability_id,
+                        "capability_id": self._capability_id,
                         "arguments": {"message": message},
                     }
                 ],
@@ -120,22 +120,18 @@ class DeterministicToolCallModel:
 async def main() -> None:
     run_context = RunContextState(config={"workspace_roots": ["."]})
 
-    gateway = DefaultToolGateway()
-    provider = NativeToolProvider(tools=[EchoTool()], context_factory=run_context.build)
-    gateway.register_provider(provider)
+    tool_manager = ToolManager(context_factory=run_context.build)
+    descriptor = tool_manager.register_tool(EchoTool())
 
-    tool_provider = GatewayToolProvider(gateway)
-    await tool_provider.refresh()
-
-    planner = EchoPlanner()
-    validator = RegistryPlanValidator(tool_gateway=gateway)
-    model = DeterministicToolCallModel()
+    planner = EchoPlanner(capability_id=descriptor.id)
+    validator = RegistryPlanValidator(tool_gateway=tool_manager)
+    model = DeterministicToolCallModel(capability_id=descriptor.id)
 
     agent = FiveLayerAgent(
         name="plan-loop-demo",
         model=model,
-        tools=tool_provider,
-        tool_gateway=gateway,
+        tools=tool_manager,
+        tool_gateway=tool_manager,
         planner=planner,
         validator=validator,
     )

--- a/examples/plan-loop/real_model_plan_loop.py
+++ b/examples/plan-loop/real_model_plan_loop.py
@@ -23,17 +23,16 @@ if str(PROJECT_ROOT) not in sys.path:
 from dare_framework.agent import FiveLayerAgent
 from dare_framework.context import Message
 from dare_framework.infra.component import ComponentType
-from dare_framework.model import OpenAIModelAdapter, Prompt
+from dare_framework.model import OpenAIModelAdapter
+from dare_framework.model.types import ModelInput
 from dare_framework.plan import ProposedPlan, ProposedStep
 from dare_framework.plan._internal.registry_validator import RegistryPlanValidator
 from dare_framework.tool import (
-    DefaultToolGateway,
     EchoTool,
-    GatewayToolProvider,
-    NativeToolProvider,
     ReadFileTool,
     RunContextState,
     SearchCodeTool,
+    ToolManager,
 )
 
 MODEL = os.getenv("CHAT_MODEL", "gpt-4o-mini")
@@ -62,12 +61,16 @@ def _tool_catalog(tool_defs: list[dict[str, Any]]) -> list[dict[str, Any]]:
         function = tool.get("function") if isinstance(tool, dict) else None
         if not isinstance(function, dict):
             continue
-        name = function.get("name")
-        if not isinstance(name, str) or not name:
+        capability_id = function.get("name")
+        if not isinstance(capability_id, str) or not capability_id:
             continue
+        display_name = tool.get("metadata", {}).get("display_name")
+        if not isinstance(display_name, str) or not display_name:
+            display_name = capability_id
         catalog.append(
             {
-                "name": name,
+                "capability_id": capability_id,
+                "name": display_name,
                 "description": function.get("description", ""),
                 "parameters": function.get("parameters", {}),
             }
@@ -125,7 +128,13 @@ class JsonPlanPlanner:
     ) -> None:
         self._model = model
         self._tool_defs = list(tool_defs)
-        self._tool_names = {tool["name"] for tool in _tool_catalog(self._tool_defs)}
+        self._tool_catalog = _tool_catalog(self._tool_defs)
+        self._tool_ids = {tool["capability_id"] for tool in self._tool_catalog}
+        self._tool_aliases: dict[str, set[str]] = {}
+        for tool in self._tool_catalog:
+            alias = tool.get("name")
+            if isinstance(alias, str) and alias:
+                self._tool_aliases.setdefault(alias, set()).add(tool["capability_id"])
         self._default_read_path = default_read_path
         self._max_steps = max_steps
         self.last_plan: ProposedPlan | None = None
@@ -140,16 +149,15 @@ class JsonPlanPlanner:
 
     async def plan(self, ctx: Any) -> ProposedPlan:
         task = _latest_user_message(ctx.stm_get()) or "unknown task"
-        tool_catalog = _tool_catalog(self._tool_defs)
-        prompt = Prompt(
+        prompt = ModelInput(
             messages=[
                 Message(
                     role="system",
                     content=(
                         "You are a planning module. Return JSON only (no markdown).\n"
                         "Format: {\"plan_description\": str, \"steps\": "
-                        "[{\"tool\": str, \"arguments\": object, \"description\": str}]}\n"
-                        "Use only tools from the provided catalog and keep steps <= max_steps."
+                        "[{\"tool_id\": str, \"arguments\": object, \"description\": str}]}\n"
+                        "Use only tool_id values from the provided catalog and keep steps <= max_steps."
                     ),
                 ),
                 Message(
@@ -158,7 +166,7 @@ class JsonPlanPlanner:
                         f"Task: {task}\n"
                         f"Default read path: {self._default_read_path}\n"
                         f"max_steps: {self._max_steps}\n"
-                        f"Tool catalog: {json.dumps(tool_catalog, ensure_ascii=True)}"
+                        f"Tool catalog: {json.dumps(self._tool_catalog, ensure_ascii=True)}"
                     ),
                 ),
             ],
@@ -189,19 +197,32 @@ class JsonPlanPlanner:
         for idx, raw in enumerate(raw_steps[: self._max_steps], start=1):
             if not isinstance(raw, dict):
                 continue
-            tool_name = raw.get("tool") or raw.get("tool_name") or raw.get("name")
-            if not isinstance(tool_name, str) or tool_name not in self._tool_names:
+            tool_token = (
+                raw.get("tool_id")
+                or raw.get("capability_id")
+                or raw.get("tool")
+                or raw.get("tool_name")
+                or raw.get("name")
+            )
+            if not isinstance(tool_token, str):
                 continue
+            if tool_token in self._tool_ids:
+                resolved_id = tool_token
+            else:
+                aliases = self._tool_aliases.get(tool_token, set())
+                if len(aliases) != 1:
+                    continue
+                resolved_id = next(iter(aliases))
             params = raw.get("arguments") or raw.get("params") or raw.get("input") or {}
             if not isinstance(params, dict):
                 params = {}
-            if tool_name == "read_file" and "path" not in params:
+            if "path" not in params and self._tool_name_for(resolved_id) == "read_file":
                 params["path"] = self._default_read_path
 
             steps.append(
                 ProposedStep(
                     step_id=f"step-{idx}",
-                    capability_id=f"tool:{tool_name}",
+                    capability_id=resolved_id,
                     params=params,
                     description=str(raw.get("description") or ""),
                 )
@@ -209,25 +230,37 @@ class JsonPlanPlanner:
 
         return steps
 
+    def _tool_name_for(self, capability_id: str) -> str:
+        for tool in self._tool_catalog:
+            if tool.get("capability_id") == capability_id:
+                return str(tool.get("name", ""))
+        return ""
+
     def _fallback_steps(self, task: str) -> list[ProposedStep]:
-        if "read_file" in self._tool_names:
-            return [
-                ProposedStep(
-                    step_id="step-1",
-                    capability_id="tool:read_file",
-                    params={"path": self._default_read_path},
-                    description="Fallback to read the default file.",
-                )
-            ]
-        if "echo" in self._tool_names:
-            return [
-                ProposedStep(
-                    step_id="step-1",
-                    capability_id="tool:echo",
-                    params={"message": task},
-                    description="Fallback to echo the task.",
-                )
-            ]
+        if "read_file" in self._tool_aliases:
+            capability_ids = self._tool_aliases.get("read_file", set())
+            if len(capability_ids) == 1:
+                capability_id = next(iter(capability_ids))
+                return [
+                    ProposedStep(
+                        step_id="step-1",
+                        capability_id=capability_id,
+                        params={"path": self._default_read_path},
+                        description="Fallback to read the default file.",
+                    )
+                ]
+        if "echo" in self._tool_aliases:
+            capability_ids = self._tool_aliases.get("echo", set())
+            if len(capability_ids) == 1:
+                capability_id = next(iter(capability_ids))
+                return [
+                    ProposedStep(
+                        step_id="step-1",
+                        capability_id=capability_id,
+                        params={"message": task},
+                        description="Fallback to echo the task.",
+                    )
+                ]
         return []
 
 
@@ -267,26 +300,24 @@ async def main() -> None:
         }
     )
 
-    tools = [ReadFileTool(), SearchCodeTool(), EchoTool()]
-    gateway = DefaultToolGateway()
-    gateway.register_provider(NativeToolProvider(tools=tools, context_factory=run_context.build))
-
-    tool_provider = GatewayToolProvider(gateway)
-    await tool_provider.refresh()
+    tool_manager = ToolManager(context_factory=run_context.build)
+    tool_manager.register_tool(ReadFileTool())
+    tool_manager.register_tool(SearchCodeTool())
+    tool_manager.register_tool(EchoTool())
 
     planner = JsonPlanPlanner(
         model,
-        tool_provider.list_tools(),
+        tool_manager.list_tool_defs(),
         default_read_path=DEFAULT_READ_PATH,
         max_steps=MAX_STEPS,
     )
-    validator = RegistryPlanValidator(tool_gateway=gateway)
+    validator = RegistryPlanValidator(tool_gateway=tool_manager)
 
     agent = FiveLayerAgent(
         name="plan-loop-real-model",
         model=model,
-        tools=tool_provider,
-        tool_gateway=gateway,
+        tools=tool_manager,
+        tool_gateway=tool_manager,
         planner=planner,
         validator=validator,
     )


### PR DESCRIPTION
- normalize plan validation against registry capabilities with async listing
- update plan-loop examples to ToolManager + ModelInput + capability ids
- add DonePredicate handling and tool loop budgeting in FiveLayerAgent

Rationale: keep plan execution consistent with tool registry identity and enforce tool-loop completion semantics.