### PR TITLE
refactor(agent): rename FiveLayerAgent to DareAgent

### DIFF
--- a/dare_framework/agent/__init__.py
+++ b/dare_framework/agent/__init__.py
@@ -4,7 +4,7 @@ from dare_framework.agent.interfaces import IAgentOrchestration
 from dare_framework.agent.kernel import IAgent
 from dare_framework.agent.types import AgentDeps
 from dare_framework.agent._internal.base import BaseAgent
-from dare_framework.agent._internal.five_layer import FiveLayerAgent
+from dare_framework.agent._internal.five_layer import DareAgent
 from dare_framework.agent._internal.simple_chat import SimpleChatAgent
 
 __all__ = [
@@ -12,6 +12,7 @@ __all__ = [
     "IAgent",
     "IAgentOrchestration",
     "BaseAgent",
-    "FiveLayerAgent",
+    "DareAgent",
     "SimpleChatAgent",
 ]
+

--- a/dare_framework/agent/_internal/five_layer.py
+++ b/dare_framework/agent/_internal/five_layer.py
@@ -1,4 +1,4 @@
-"""FiveLayerAgent - Five-layer loop agent implementation.
+"""DareAgent - DARE Framework agent implementation.
 
 This agent implements the full five-layer orchestration loop:
 1. Session Loop - Top-level task lifecycle
@@ -55,8 +55,8 @@ if TYPE_CHECKING:
     from dare_framework.tool.kernel import IExecutionControl, IToolGateway
 
 
-class FiveLayerAgent(BaseAgent):
-    """Five-layer loop agent implementation.
+class DareAgent(BaseAgent):
+    """DARE Framework agent implementation.
 
     This agent implements the IAgentOrchestration interface and supports
     the full five-layer orchestration loop while allowing graceful
@@ -67,9 +67,14 @@ class FiveLayerAgent(BaseAgent):
         - Overrides BaseAgent.run() to delegate to execute()
         - Preserves _execute() for BaseAgent compatibility
 
+    Modes:
+        - **Full Five-Layer**: planner provided → Session→Milestone→Plan→Execute→Tool
+        - **ReAct Mode**: no planner, has tools → Execute→Tool loop directly
+        - **Simple Mode**: no planner, no tools → Single model generation
+
     Example:
         # Full five-layer mode
-        agent = FiveLayerAgent(
+        agent = DareAgent(
             name="full-agent",
             model=model,
             planner=planner,
@@ -77,7 +82,7 @@ class FiveLayerAgent(BaseAgent):
         )
 
         # ReAct mode (no planner/validator)
-        agent = FiveLayerAgent(
+        agent = DareAgent(
             name="react-agent",
             model=model,
             tool_gateway=gateway,
@@ -110,7 +115,7 @@ class FiveLayerAgent(BaseAgent):
         max_plan_attempts: int = 3,
         max_tool_iterations: int = 20,
     ) -> None:
-        """Initialize FiveLayerAgent.
+        """Initialize DareAgent.
 
         Args:
             name: Agent name identifier.
@@ -849,7 +854,7 @@ class FiveLayerAgent(BaseAgent):
         await self._event_log.append(event_type, payload)
 
 
-__all__ = ["FiveLayerAgent"]
+__all__ = ["DareAgent"]
 
 
 def _done_predicate_satisfied(done_predicate: DonePredicate, result: Any) -> bool:
@@ -863,3 +868,4 @@ def _done_predicate_satisfied(done_predicate: DonePredicate, result: Any) -> boo
         if key not in output:
             return False
     return True
+

--- a/dare_framework/builder/__init__.py
+++ b/dare_framework/builder/__init__.py
@@ -1,5 +1,5 @@
 """Builder facade for composing agents."""
 
-from dare_framework.builder.builder import Builder, FiveLayerAgentBuilder, SimpleChatAgentBuilder
+from dare_framework.builder.builder import Builder, DareAgentBuilder, SimpleChatAgentBuilder
 
-__all__ = ["Builder", "FiveLayerAgentBuilder", "SimpleChatAgentBuilder"]
+__all__ = ["Builder", "DareAgentBuilder", "SimpleChatAgentBuilder"]

--- a/dare_framework/builder/builder.py
+++ b/dare_framework/builder/builder.py
@@ -2,7 +2,7 @@
 
 This module provides two public builders:
 - SimpleChatAgentBuilder: builds SimpleChatAgent (simple chat mode)
-- FiveLayerAgentBuilder: builds FiveLayerAgent (five-layer orchestration)
+- DareAgentBuilder: builds DareAgent (five-layer orchestration)
 
 All builder variants share the same precedence rules:
 1) Explicit builder injection wins (highest precedence).
@@ -15,7 +15,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable, TypeVar
 
-from dare_framework.agent import FiveLayerAgent, SimpleChatAgent
+from dare_framework.agent import DareAgent, SimpleChatAgent
 from dare_framework.config.types import Config
 from dare_framework.context import Budget, Context
 from dare_framework.event.kernel import IEventLog
@@ -344,8 +344,8 @@ class SimpleChatAgentBuilder(_BaseAgentBuilder):
         )
 
 
-class FiveLayerAgentBuilder(_BaseAgentBuilder):
-    """Builder for FiveLayerAgent (five-layer orchestration)."""
+class DareAgentBuilder(_BaseAgentBuilder):
+    """Builder for DareAgent (five-layer orchestration)."""
 
     def __init__(self, name: str) -> None:
         super().__init__(name)
@@ -358,31 +358,31 @@ class FiveLayerAgentBuilder(_BaseAgentBuilder):
         self._execution_control: IExecutionControl | None = None
         self._hooks: list[IHook] = []
 
-    def with_planner(self, planner: IPlanner) -> "FiveLayerAgentBuilder":
+    def with_planner(self, planner: IPlanner) -> "DareAgentBuilder":
         self._planner = planner
         return self
 
-    def add_validators(self, *validators: IValidator) -> "FiveLayerAgentBuilder":
+    def add_validators(self, *validators: IValidator) -> "DareAgentBuilder":
         self._validators.extend(validators)
         return self
 
-    def with_remediator(self, remediator: IRemediator) -> "FiveLayerAgentBuilder":
+    def with_remediator(self, remediator: IRemediator) -> "DareAgentBuilder":
         self._remediator = remediator
         return self
 
-    def with_event_log(self, event_log: IEventLog) -> "FiveLayerAgentBuilder":
+    def with_event_log(self, event_log: IEventLog) -> "DareAgentBuilder":
         self._event_log = event_log
         return self
 
-    def with_execution_control(self, execution_control: IExecutionControl) -> "FiveLayerAgentBuilder":
+    def with_execution_control(self, execution_control: IExecutionControl) -> "DareAgentBuilder":
         self._execution_control = execution_control
         return self
 
-    def add_hooks(self, *hooks: IHook) -> "FiveLayerAgentBuilder":
+    def add_hooks(self, *hooks: IHook) -> "DareAgentBuilder":
         self._hooks.extend(hooks)
         return self
 
-    def build(self) -> FiveLayerAgent:
+    def build(self) -> DareAgent:
         model = self._resolved_model()
         sys_prompt = self._resolve_sys_prompt(model)
 
@@ -446,7 +446,7 @@ class FiveLayerAgentBuilder(_BaseAgentBuilder):
             if tool_provider is not None:
                 context._tool_provider = tool_provider
             context._sys_prompt = sys_prompt
-            return FiveLayerAgent(
+            return DareAgent(
                 name=self._name,
                 model=model,
                 context=context,
@@ -465,7 +465,7 @@ class FiveLayerAgentBuilder(_BaseAgentBuilder):
             setattr(self._context, "_tool_provider", tool_provider)
         setattr(self._context, "_sys_prompt", sys_prompt)
 
-        return FiveLayerAgent(
+        return DareAgent(
             name=self._name,
             model=model,
             context=self._context,
@@ -488,11 +488,11 @@ class Builder:
         return SimpleChatAgentBuilder(name)
 
     @staticmethod
-    def five_layer_agent_builder(name: str) -> FiveLayerAgentBuilder:
-        return FiveLayerAgentBuilder(name)
+    def five_layer_agent_builder(name: str) -> DareAgentBuilder:
+        return DareAgentBuilder(name)
 
 
-__all__ = ["Builder", "FiveLayerAgentBuilder", "SimpleChatAgentBuilder"]
+__all__ = ["Builder", "DareAgentBuilder", "SimpleChatAgentBuilder"]
 
 
 class _ConfiguredToolProvider(IToolProvider):

--- a/tests/unit/test_five_layer_agent.py
+++ b/tests/unit/test_five_layer_agent.py
@@ -1,4 +1,4 @@
-"""Unit tests for FiveLayerAgent."""
+"""Unit tests for DareAgent."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from dare_framework.agent import FiveLayerAgent
+from dare_framework.agent import DareAgent
 from dare_framework.context import Budget, Context, Message
 from dare_framework.model.types import ModelInput, ModelResponse
 from dare_framework.tool.types import CapabilityDescriptor, CapabilityKind, CapabilityType
@@ -112,13 +112,13 @@ class MockEventLog:
 # =============================================================================
 
 
-class TestFiveLayerAgentInit:
-    """Tests for FiveLayerAgent initialization."""
+class TestDareAgentInit:
+    """Tests for DareAgent initialization."""
 
     def test_init_with_minimal_deps(self) -> None:
         """Agent can be created with only required dependencies."""
         model = MockModelAdapter()
-        agent = FiveLayerAgent(name="test-agent", model=model)
+        agent = DareAgent(name="test-agent", model=model)
 
         assert agent.name == "test-agent"
         assert agent.context is not None
@@ -129,7 +129,7 @@ class TestFiveLayerAgentInit:
         """Agent can use a provided context."""
         model = MockModelAdapter()
         context = Context(id="custom-context", budget=Budget(max_tokens=1000))
-        agent = FiveLayerAgent(name="test-agent", model=model, context=context)
+        agent = DareAgent(name="test-agent", model=model, context=context)
 
         assert agent.context.id == "custom-context"
 
@@ -137,7 +137,7 @@ class TestFiveLayerAgentInit:
         """Providing a planner enables full five-layer mode."""
         model = MockModelAdapter()
         planner = MockPlanner()
-        agent = FiveLayerAgent(name="test-agent", model=model, planner=planner)
+        agent = DareAgent(name="test-agent", model=model, planner=planner)
 
         assert agent.is_full_five_layer_mode
 
@@ -149,7 +149,7 @@ class TestFiveLayerAgentInit:
         tool_gateway = MockToolGateway()
         event_log = MockEventLog()
 
-        agent = FiveLayerAgent(
+        agent = DareAgent(
             name="full-agent",
             model=model,
             planner=planner,
@@ -169,7 +169,7 @@ class TestFiveLayerAgentInit:
         from dare_framework.agent.interfaces import IAgentOrchestration
 
         model = MockModelAdapter()
-        agent = FiveLayerAgent(name="test-agent", model=model)
+        agent = DareAgent(name="test-agent", model=model)
 
         # Verify execute method exists with correct signature
         assert hasattr(agent, "execute")
@@ -185,8 +185,8 @@ class TestFiveLayerAgentInit:
 # =============================================================================
 
 
-class TestFiveLayerAgentExecution:
-    """Tests for FiveLayerAgent execution."""
+class TestDareAgentExecution:
+    """Tests for DareAgent execution."""
 
     @pytest.mark.asyncio
     async def test_simple_task_without_tools(self) -> None:
@@ -194,7 +194,7 @@ class TestFiveLayerAgentExecution:
         model = MockModelAdapter([
             ModelResponse(content="The answer is 42.", tool_calls=[])
         ])
-        agent = FiveLayerAgent(name="test-agent", model=model)
+        agent = DareAgent(name="test-agent", model=model)
 
         result = await agent.run("What is the answer?")
 
@@ -207,7 +207,7 @@ class TestFiveLayerAgentExecution:
         """Events are logged when event_log is provided."""
         model = MockModelAdapter()
         event_log = MockEventLog()
-        agent = FiveLayerAgent(name="test-agent", model=model, event_log=event_log)
+        agent = DareAgent(name="test-agent", model=model, event_log=event_log)
 
         await agent.run("Test task")
 
@@ -232,7 +232,7 @@ class TestFiveLayerAgentExecution:
             metadata={},
         ))
 
-        agent = FiveLayerAgent(name="test-agent", model=model, context=context)
+        agent = DareAgent(name="test-agent", model=model, context=context)
         await agent.run("Test task")
 
         # Budget check should be called multiple times
@@ -252,7 +252,7 @@ class TestReActMode:
         """Without planner but with tools, runs in ReAct mode."""
         model = MockModelAdapter()
         tool_gateway = MockToolGateway()
-        agent = FiveLayerAgent(name="react-agent", model=model, tool_gateway=tool_gateway)
+        agent = DareAgent(name="react-agent", model=model, tool_gateway=tool_gateway)
 
         # Should be in react mode
         assert agent.is_react_mode
@@ -274,7 +274,7 @@ class TestReActMode:
             ModelResponse(content="Done!", tool_calls=[]),
         ])
         tool_gateway = MockToolGateway()
-        agent = FiveLayerAgent(
+        agent = DareAgent(
             name="react-agent",
             model=model,
             tool_gateway=tool_gateway,
@@ -300,7 +300,7 @@ class TestFiveLayerMode:
         model = MockModelAdapter()
         planner = MockPlanner()
         validator = MockValidator()
-        agent = FiveLayerAgent(
+        agent = DareAgent(
             name="five-layer-agent",
             model=model,
             planner=planner,
@@ -318,7 +318,7 @@ class TestFiveLayerMode:
         model = MockModelAdapter()
         planner = MockPlanner()
         validator = MockValidator()
-        agent = FiveLayerAgent(
+        agent = DareAgent(
             name="five-layer-agent",
             model=model,
             planner=planner,
@@ -352,7 +352,7 @@ class TestFiveLayerMode:
         planner = MockPlanner()
         validator = MockValidator()
         tool_gateway = MockToolGateway([plan_tool])
-        agent = FiveLayerAgent(
+        agent = DareAgent(
             name="five-layer-agent",
             model=model,
             planner=planner,


### PR DESCRIPTION
- Rename FiveLayerAgent class to DareAgent in five_layer.py
- Update agent/__init__.py to export DareAgent
- Rename FiveLayerAgentBuilder to DareAgentBuilder in builder.py
- Update builder/__init__.py to export DareAgentBuilder
- Update test_five_layer_agent.py to use DareAgent
- Preserves @bouillipx's _done_predicate_satisfied function from merge

Note: examples/ will be updated in a separate PR per team decision