### PR TITLE
docs: align example readmes with progressive flow

### DIFF
--- a/examples/01-basic-chat/README.md
+++ b/examples/01-basic-chat/README.md
@@ -1,6 +1,6 @@
 # 01-basic-chat
 
-最简单的对话 Agent 示例，展示 `SimpleChatAgentBuilder` 的最小用法。
+最小可运行对话 Agent。作为所有示例的起点，后续示例在此基础上逐步增加工具、可观测性与多层循环。
 
 ## 运行
 
@@ -25,10 +25,23 @@ agent = (
 result = await agent.run("Hello!")
 ```
 
+## 进阶点
+
+- 起点示例：最小化 Builder 链路（`simple_chat_agent_builder` + `with_model` + `build`）
+- 不执行工具调用，仅返回文本响应
+
 ## Prompt 管理
 
 系统提示由框架 Prompt Store 管理（默认 `base.system`），无需在示例中手写系统提示。
 如需覆盖，使用 `.dare/_prompts.json` 配置。
+
+## 文件结构
+
+```
+01-basic-chat/
+├── main.py
+└── README.md
+```
 
 ## 适用场景
 

--- a/examples/02-with-tools/README.md
+++ b/examples/02-with-tools/README.md
@@ -1,6 +1,6 @@
 # 02-with-tools
 
-带工具的 Agent 示例，展示如何使用 `add_tools()` 添加文件操作能力。
+在 01 的基础上加入工具调用与 ReAct 循环，演示 `add_tools()` 与工作区限制。
 
 ## 运行
 
@@ -33,17 +33,24 @@ agent = (
 )
 ```
 
+## 进阶点
+
+- 相对 01，新增 ReAct 模式（Reason → Act → Observe），模型 tool_call 会被执行
+- `with_run_context_factory()` 限定 `workspace_roots`，工具只能读写该目录下的路径
+- 工具 `name` 为唯一 capability id，自定义工具需保证名称唯一
+
 ## Prompt 管理
 
 系统提示由框架 Prompt Store 管理（默认 `base.system`），无需在示例中手写系统提示。
+如需覆盖，使用 `.dare/_prompts.json` 配置。
 
-## 工具命名规则
+## 文件结构
 
-工具 `name` 是唯一主键（capability id）。自定义工具时必须保证名称唯一。
-
-## 执行模式
-
-ReAct 模式：Reason → Act → Observe 循环
+```
+02-with-tools/
+├── main.py
+└── README.md
+```
 
 ## 适用场景
 

--- a/examples/03-observability/README.md
+++ b/examples/03-observability/README.md
@@ -1,6 +1,6 @@
 # 03-observability
 
-演示基于 OpenTelemetry 的可观测性接入。
+在 02 的基础上加入 OpenTelemetry 可观测性，聚焦埋点、指标与输出汇总（本示例不强调工具调用）。
 
 ## 运行
 
@@ -9,7 +9,7 @@ cd examples/03-observability
 export OPENROUTER_API_KEY="your-api-key"
 # 可选：指定模型
 export OPENROUTER_MODEL="z-ai/glm-4.7"
-# 可选：限制最大输出 tokens
+# 可选：限制最大输出 tokens，避免信用不足错误
 export OPENROUTER_MAX_TOKENS="2048"
 python main.py
 ```
@@ -38,11 +38,25 @@ builder = (
 agent = await builder.build()
 ```
 
-## 输出示例
+## 进阶点
 
-执行后可看到两类输出：
-- Recorder 汇总（spans/metrics）
-- OpenTelemetry console exporter 输出（如启用）
+- 相对 02，新增可观测性：TelemetryProvider + ObservabilityHook
+- 内置 `RecordingTelemetryProvider`，结束后打印 spans/metrics 汇总
+- 若安装 OTel SDK 且设置 `exporter_type=console`，控制台会输出 trace/metrics
+- 示例聚焦观测，不展示工具调用（如需工具可参考 02）
+
+## Prompt 管理
+
+系统提示由框架 Prompt Store 管理（默认 `base.system`），无需在示例中手写系统提示。
+如需覆盖，使用 `.dare/_prompts.json` 配置。
+
+## 文件结构
+
+```
+03-observability/
+├── main.py
+└── README.md
+```
 
 ## 适用场景
 

--- a/examples/04-dare-coding-agent/README.md
+++ b/examples/04-dare-coding-agent/README.md
@@ -1,18 +1,18 @@
-# 03-dare-coding-agent
+# 04-dare-coding-agent
 
-使用 `DareAgentBuilder` 演示完整五层循环，并提供可演示的交互式 CLI。
+在 01–03 基础上加入完整五层循环、计划/执行模式与验证修复流程，提供可演示的交互式 CLI。
 
-## 快速开始
+## 运行
 
 ```bash
-# 进入目录
-cd examples/03-dare-coding-agent
-
-# 配置环境（OpenRouter）
-cp .env.example .env
-# 编辑 .env 添加你的 OPENROUTER_API_KEY
-
-# 运行交互式 CLI
+cd examples/04-dare-coding-agent
+export OPENROUTER_API_KEY="your-api-key"
+# 可选：指定模型
+export OPENROUTER_MODEL="z-ai/glm-4.7"
+# 可选：限制最大输出 tokens，避免信用不足错误
+export OPENROUTER_MAX_TOKENS="2048"
+# 可选：限制请求时间（秒）
+export OPENROUTER_TIMEOUT="60"
 python main.py
 ```
 
@@ -20,7 +20,7 @@ python main.py
 若账号 credits 较少，建议设置 `OPENROUTER_MAX_TOKENS=2048`。
 如需限制请求时间，可设置 `OPENROUTER_TIMEOUT=60`（秒）。
 
-## CLI 用法
+### CLI 用法
 
 交互命令：
 - `/mode plan`：计划预览模式（先生成计划，等待 /approve 执行）
@@ -41,19 +41,7 @@ python cli.py --demo demo_script.txt
 python demo.py
 ```
 
-## 架构
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Session Loop (跨 Context Window)                                │
-│  └─ Milestone Loop (Observe → Plan → Execute → Verify)           │
-│     ├─ Plan Loop (生成证据型计划)                                 │
-│     ├─ Execute Loop (LLM 驱动执行)                               │
-│     └─ Tool Loop (工具调用)                                       │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-## 核心代码（简化）
+## 代码要点
 
 ```python
 agent = (
@@ -67,19 +55,34 @@ agent = (
 )
 ```
 
-## Prompt 管理说明
+## 进阶点
+
+- 相对前面示例，新增完整五层循环（Session → Milestone → Plan/Execute → Tool）
+- 计划预览与审批：`/mode plan` + `/approve`；直接执行：`/mode execute`
+- 引入验证与修复流程：Validator + Remediator
+- 工具 `name` 为唯一 capability id，自定义工具需保证名称唯一
+
+**架构（五层循环）**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Session Loop (跨 Context Window)                                │
+│  └─ Milestone Loop (Observe → Plan → Execute → Verify)           │
+│     ├─ Plan Loop (生成证据型计划)                                 │
+│     ├─ Execute Loop (LLM 驱动执行)                               │
+│     └─ Tool Loop (工具调用)                                       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Prompt 管理
 
 系统提示由框架 Prompt Store 管理（默认 `base.system`），无需在示例中手写系统提示。
 如需覆盖，使用 `.dare/_prompts.json` 配置。
 
-## 工具命名规则
-
-工具 `name` 是唯一主键（capability id）。自定义工具时必须保证名称唯一。
-
 ## 文件结构
 
 ```
-03-dare-coding-agent/
+04-dare-coding-agent/
 ├── main.py
 ├── cli.py
 ├── demo.py
@@ -89,3 +92,9 @@ agent = (
 ├── workspace/
 └── README.md
 ```
+
+## 适用场景
+
+- 复杂任务拆解与执行
+- 带审批的自动化流程
+- 演示五层循环与验证修复机制

--- a/examples/05-dare-coding-agent-enhanced/README.md
+++ b/examples/05-dare-coding-agent-enhanced/README.md
@@ -1,18 +1,18 @@
-# 04-dare-coding-agent-enhanced
+# 05-dare-coding-agent-enhanced
 
-使用 `DareAgentBuilder` 演示完整五层循环，并提供可演示的交互式 CLI。本示例同时集成**本地 MCP 服务**作为 tool，以及 **Knowledge（rawdata 内存存储）**：Agent 可调用 MCP 工具（如 `local_math:add`）和知识库工具 `knowledge_get` / `knowledge_add`。MCP 服务由本仓库自带的 Python 脚本实现，无需 Node/npx。
+在 04 的基础上加入本地 MCP 服务与 Knowledge（rawdata 内存存储），并支持 Skill 动态挂载。
 
-## 快速开始
+## 运行
 
 ```bash
-# 进入目录
-cd examples/04-dare-coding-agent-enhanced
-
-# 配置环境（OpenRouter）
-cp .env.example .env
-# 编辑 .env 添加你的 OPENROUTER_API_KEY
-
-# 运行交互式 CLI
+cd examples/05-dare-coding-agent-enhanced
+export OPENROUTER_API_KEY="your-api-key"
+# 可选：指定模型
+export OPENROUTER_MODEL="z-ai/glm-4.7"
+# 可选：限制最大输出 tokens，避免信用不足错误
+export OPENROUTER_MAX_TOKENS="2048"
+# 可选：限制请求时间（秒）
+export OPENROUTER_TIMEOUT="60"
 python main.py
 ```
 
@@ -20,7 +20,7 @@ python main.py
 若账号 credits 较少，建议设置 `OPENROUTER_MAX_TOKENS=2048`。
 如需限制请求时间，可设置 `OPENROUTER_TIMEOUT=60`（秒）。
 
-## CLI 用法
+### CLI 用法
 
 交互命令：
 - `/mode plan`：计划预览模式（先生成计划，等待 /approve 执行）
@@ -41,19 +41,19 @@ python cli.py --demo demo_script.txt
 python demo.py
 ```
 
-## 架构
+### 启动本地 MCP 服务（体验 MCP 工具时必需）
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  Session Loop (跨 Context Window)                                │
-│  └─ Milestone Loop (Observe → Plan → Execute → Verify)           │
-│     ├─ Plan Loop (生成证据型计划)                                 │
-│     ├─ Execute Loop (LLM 驱动执行)                               │
-│     └─ Tool Loop (工具调用)                                       │
-└─────────────────────────────────────────────────────────────────┘
+```bash
+# 终端 1：先启动 MCP 服务（默认监听 127.0.0.1:8765）
+cd examples/05-dare-coding-agent-enhanced
+python local_mcp_server.py
+
+# 终端 2：再启动 Agent/CLI，会连接该服务
+cd examples/05-dare-coding-agent-enhanced
+python main.py
 ```
 
-## 核心代码（简化）
+## 代码要点
 
 ```python
 from dare_framework.knowledge import RawDataKnowledge, InMemoryRawDataStorage
@@ -71,7 +71,25 @@ agent = (
 )
 ```
 
-## Skill 挂载
+## 进阶点
+
+- 相对 04，新增 Knowledge（rawdata + 内存存储）与 MCP 工具接入
+- 支持 Skill 动态挂载（Builder / Config / 运行时）
+- 继承 04 的五层循环与计划/执行模式
+
+**架构（五层循环）**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Session Loop (跨 Context Window)                                │
+│  └─ Milestone Loop (Observe → Plan → Execute → Verify)           │
+│     ├─ Plan Loop (生成证据型计划)                                 │
+│     ├─ Execute Loop (LLM 驱动执行)                               │
+│     └─ Tool Loop (工具调用)                                       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Skill 挂载**
 
 一个 agent 同时只支持一个 skill。框架支持：
 
@@ -97,12 +115,7 @@ my_skill/
     └── check.sh
 ```
 
-## Prompt 管理说明
-
-系统提示由框架 Prompt Store 管理（默认 `base.system`），并自动合并 skill 内容。
-如需覆盖，使用 `.dare/_prompts.json` 配置。
-
-## Knowledge（本示例）
+**Knowledge（本示例）**
 
 本示例使用 **rawdata 知识库 + 内存存储**（`RawDataKnowledge(storage=InMemoryRawDataStorage())`），Agent 可通过工具调用知识库：
 
@@ -113,36 +126,18 @@ my_skill/
 
 知识库与本地工具、MCP 工具一起注册到工具列表，可在任务中直接让 Agent 调用（例如：「把这句话记到知识库」或「从知识库查一下和 Python 相关的内容」）。
 
-## 工具命名规则
+**MCP 本地服务（本示例）**
 
-工具 `name` 是唯一主键（capability id）。自定义工具时必须保证名称唯一。
+本示例在 `.dare/mcp/` 下配置了**本地 MCP 服务**，Agent 通过 HTTP 连接该服务并调用其工具。服务需**你先单独启动**，再启动 CLI。
 
-## MCP 本地服务（本示例）
+配置与实现：
 
-本示例在 `.dare/mcp/` 下配置了**本地 MCP 服务**，Agent 通过 HTTP 连接该服务并调用其工具。服务需**你先单独启动**，再启动 CLI，这样才是“真正的服务”形态。
+- **目录**：`05-dare-coding-agent-enhanced/.dare/mcp/`
+- **当前配置**：`local_math.json` — HTTP 连接 `http://127.0.0.1:8765/`
+- **脚本**：`local_mcp_server.py` — 以 HTTP 方式提供 MCP 协议，暴露 `add` / `subtract` / `multiply` / `divide`
+- **依赖**：仅标准库，与 Agent 同环境 Python 即可
 
-### 配置
-
-- **目录**：`04-dare-coding-agent-enhanced/.dare/mcp/`
-- **当前配置**：`local_math.json` — HTTP 连接 `http://127.0.0.1:8765/`（服务需先在本机启动）。
-
-### 本地 MCP 服务实现
-
-- **脚本**：`local_mcp_server.py` — 以 HTTP 方式提供 MCP 协议，暴露四个工具：`add`（加）、`subtract`（减）、`multiply`（乘）、`divide`（除），用于验证「一个服务提供多个 tool」。
-- **依赖**：仅标准库，与 Agent 同环境 Python 即可。
-- **启动方式**：**你先在终端 1 运行服务**，再在终端 2 运行 CLI：
-
-  ```bash
-  # 终端 1：先启动 MCP 服务（默认监听 127.0.0.1:8765）
-  cd examples/04-dare-coding-agent-enhanced
-  python local_mcp_server.py
-
-  # 终端 2：再启动 Agent/CLI，会连接该服务
-  cd examples/04-dare-coding-agent-enhanced
-  python main.py
-  ```
-
-### 提供的 MCP 工具（local_math 服务器，一个服务四个 tool）
+提供的 MCP 工具（local_math 服务器，一个服务四个 tool）：
 
 | 工具名 | 说明 |
 |--------|------|
@@ -157,12 +152,17 @@ my_skill/
 
 ### 自定义 MCP 配置
 
-在 `.dare/mcp/` 下新增或修改 JSON 文件即可，支持单服务或多服务格式。详见框架 [MCP 文档](../../dare_framework/mcp/)。
+在 `.dare/mcp/` 下新增或修改 JSON 文件即可，支持单服务或多服务格式。
+
+## Prompt 管理
+
+系统提示由框架 Prompt Store 管理（默认 `base.system`），并自动合并 skill 内容。
+如需覆盖，使用 `.dare/_prompts.json` 配置。
 
 ## 文件结构
 
 ```
-04-dare-coding-agent-enhanced/
+05-dare-coding-agent-enhanced/
 ├── main.py
 ├── cli.py
 ├── demo.py
@@ -176,3 +176,9 @@ my_skill/
 ├── workspace/
 └── README.md
 ```
+
+## 适用场景
+
+- 本地 MCP 服务与多工具协作验证
+- Knowledge 读写与长期记忆实验
+- 技能动态挂载与 CLI 演示

--- a/examples/05-dare-coding-agent-enhanced/local_mcp_server.py
+++ b/examples/05-dare-coding-agent-enhanced/local_mcp_server.py
@@ -7,7 +7,7 @@
 
 用法：
   终端 1：python local_mcp_server.py          # 服务默认监听 http://127.0.0.1:8765
-  终端 2：cd examples/04-dare-coding-agent-enhanced && python main.py   # CLI 连接该服务
+  终端 2：cd examples/05-dare-coding-agent-enhanced && python main.py   # CLI 连接该服务
 """
 from __future__ import annotations
 


### PR DESCRIPTION
Unify 01–05 README structure (run, code, progression, prompts, files, scenarios). Fix example numbering and paths for 04/05 to match directories. Update MCP server usage comments to reference the correct enhanced example path.