### PR TITLE
fix(tool): align capability listing API and restore descriptor flow

### DIFF
--- a/dare_framework/context/context.py
+++ b/dare_framework/context/context.py
@@ -159,7 +159,16 @@ class Context(IContext):
     def list_tools(self) -> list[CapabilityDescriptor]:
         """Get tool list from a ToolManager or provider."""
         if self._tool_gateway is not None:
-            return self._tool_gateway.list_capabilities()
+            list_capabilities_sync = getattr(self._tool_gateway, "list_capabilities_sync", None)
+            if callable(list_capabilities_sync):
+                return list_capabilities_sync()
+
+            # Backward compatibility for legacy sync gateways.
+            list_capabilities = getattr(self._tool_gateway, "list_capabilities", None)
+            if callable(list_capabilities):
+                capabilities = list_capabilities()
+                if not hasattr(capabilities, "__await__"):
+                    return capabilities
         return []
 
     # ========== Assembly Methods (Core) ==========

--- a/dare_framework/tool/kernel.py
+++ b/dare_framework/tool/kernel.py
@@ -114,7 +114,7 @@ class IToolGateway(ABC):
     """System-call boundary and trusted capability registry facade."""
 
     @abstractmethod
-    def list_capabilities(self) -> list[CapabilityDescriptor]: ...
+    async def list_capabilities(self) -> list[CapabilityDescriptor]: ...
 
     @abstractmethod
     async def invoke(

--- a/dare_framework/tool/tool_manager.py
+++ b/dare_framework/tool/tool_manager.py
@@ -173,7 +173,7 @@ class ToolManager(IToolManager, IToolGateway):
         self.load_entrypoint_providers()
         for provider in self._providers:
             self._sync_provider_tools(provider, provider.list_tools())
-        return self.list_capabilities(include_disabled=True)
+        return await self.list_capabilities(include_disabled=True)
 
     def load_tools(self, *, config: Config | None = None) -> list[ITool]:
         self.load_entrypoint_providers()
@@ -184,13 +184,16 @@ class ToolManager(IToolManager, IToolGateway):
             tools.append(entry.tool)
         return tools
 
-    def list_capabilities(self, *, include_disabled: bool = False) -> list[CapabilityDescriptor]:
+    def list_capabilities_sync(self, *, include_disabled: bool = False) -> list[CapabilityDescriptor]:
         descriptors: list[CapabilityDescriptor] = []
         for entry in self._registry.values():
             if not include_disabled and not entry.enabled:
                 continue
             descriptors.append(entry.descriptor)
         return descriptors
+
+    async def list_capabilities(self, *, include_disabled: bool = False) -> list[CapabilityDescriptor]:
+        return self.list_capabilities_sync(include_disabled=include_disabled)
 
     def list_tool_defs(self) -> list[ToolDefinition]:
         tool_defs: list[ToolDefinition] = []

--- a/tests/unit/test_context_implementation.py
+++ b/tests/unit/test_context_implementation.py
@@ -4,6 +4,8 @@ from dare_framework.config import Config
 from dare_framework.context.context import Context
 from dare_framework.context.types import Message, Budget
 from dare_framework.model import Prompt
+from dare_framework.tool._internal.tools.noop_tool import NoopTool
+from dare_framework.tool.tool_manager import ToolManager
 
 def test_context_initialization():
     config = Config()
@@ -62,3 +64,15 @@ def test_context_assemble():
 def test_context_requires_non_null_config():
     with pytest.raises(ValueError, match="non-null Config"):
         Context(id="missing-config", config=None)  # type: ignore[arg-type]
+
+
+def test_context_list_tools_returns_capability_descriptors_from_tool_manager():
+    manager = ToolManager(load_entrypoints=False)
+    manager.register_tool(NoopTool())
+    ctx = Context(config=Config(), tool_gateway=manager)
+
+    tools = ctx.list_tools()
+
+    assert len(tools) == 1
+    assert tools[0].id == "noop"
+    assert tools[0].name == "noop"


### PR DESCRIPTION
Make capability listing contract consistent by defining IToolGateway.list_capabilities as async and updating ToolManager accordingly.

Add ToolManager.list_capabilities_sync for synchronous consumers and route Context.list_tools to this sync path so model adapters still receive CapabilityDescriptor objects.

Keep a legacy fallback for old sync gateways and add a regression test verifying Context.list_tools returns descriptors from ToolManager.

This fixes the runtime failure in coding-agent examples where adapters crashed with: 'dict' object has no attribute 'name'.