### PR TITLE
chore(ci): phase-1 main merge gates + PR/agent governance baseline

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+## Summary
+- What does this PR change?
+- Why is this change needed?
+
+## Scope (One PR One Thing)
+- Primary objective:
+- Out of scope:
+- I confirm this PR handles a single objective only: [ ] Yes
+
+## Changed Files (required)
+List all touched files and why each file changed.
+
+| File | Reason |
+| --- | --- |
+| path/to/file | reason |
+
+If this PR is a large diff (>300 changed lines), explain why split PRs are not possible and provide a split follow-up plan.
+
+## Acceptance Criteria
+- [ ] Criteria 1
+- [ ] Criteria 2
+
+## Test Evidence (required)
+- Local commands run:
+  - `...`
+- CI links or job names:
+  - `...`
+- Evidence/output summary:
+  - `...`
+
+## Risk and Rollback
+- Risk level: Low / Medium / High
+- Main risk points:
+- Rollback plan:
+
+## Agent Rules Checklist (required)
+Reference: `docs/agent_rules.md`
+
+- [ ] Only task-related files changed; no opportunistic refactor
+- [ ] Public interfaces/data structures unchanged unless explicitly required
+- [ ] Tests added/updated and evidence attached
+- [ ] Any `skip/only/exclude` usage is explained and reviewed

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,0 +1,48 @@
+name: ci-gate
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  # Keep one active run per ref/workflow so fast follow-up pushes cancel stale checks.
+  group: ci-gate-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install lint tooling
+        run: python -m pip install --upgrade pip ruff
+
+      - name: Run lint gate (phase-1 syntax/parser safety)
+        run: ruff check dare_framework tests --select E9,F63,F7
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build gate (phase-1 compile check)
+        run: python -m compileall -q dare_framework tests

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+# Default owner
+* @zts212653
+
+# Governance and merge gates
+/.github/workflows/* @zts212653
+/.github/pull_request_template.md @zts212653
+/CONTRIBUTING.md @zts212653
+/CONTRIBUTING_AI.md @zts212653
+/docs/agent_rules.md @zts212653
+/docs/governance/* @zts212653

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing Guide
+
+This repository uses PR-based delivery with CI gates to keep `main` stable under parallel agent development.
+
+## Branching and Merge Policy
+- Do not push directly to `main`.
+- Use feature branches and open a PR.
+- Keep each PR focused on one objective.
+- Fill every section of `.github/pull_request_template.md`.
+
+## Required CI Checks (phase-1)
+- `lint` (Ruff syntax/parser safety set)
+- `build` (Python compile check)
+
+These checks are designed to be fast and low-friction first. We will tighten them in later phases.
+
+## Run Checks Locally
+```bash
+python -m pip install -r requirements.txt
+ruff check dare_framework tests --select E9,F63,F7
+python -m compileall -q dare_framework tests
+```
+
+## Team Agent Rules
+Read and follow `docs/agent_rules.md` before opening a PR.
+
+## Governance Setup
+For GitHub branch protection and merge queue settings, follow `docs/governance/branch-protection.md`.

--- a/docs/agent_rules.md
+++ b/docs/agent_rules.md
@@ -1,0 +1,15 @@
+# Agent Development Rules (Mandatory)
+
+These rules apply to all agent-generated changes in this repository.
+
+## Agent 开发强制规则
+1. 只改与任务直接相关文件，禁止顺手重构与无关优化。
+2. 一个 PR 只做一件事，超出范围必须拆分。
+3. 不得修改公共接口/数据结构，除非任务明确且给出影响分析。
+4. 必须补测试或更新测试，并附上本地/CI 的测试证据。
+5. 任何跳过测试（skip/only/exclude）必须说明理由并经过 review。
+
+## Operating Notes
+- Keep diffs small to reduce merge conflicts in multi-agent parallel work.
+- If a change is risky, split it into follow-up PRs instead of broad refactors.
+- Prefer adding new files over editing large existing files when possible.

--- a/docs/governance/branch-protection.md
+++ b/docs/governance/branch-protection.md
@@ -1,0 +1,40 @@
+# Main Branch Protection and Merge Queue Setup
+
+This checklist is the source of truth for enabling merge gates on `main`.
+
+## Required GitHub Settings for `main`
+In **Settings -> Branches -> Add rule** (branch name pattern: `main`):
+
+1. Enable `Require a pull request before merging`.
+2. Set required approvals to at least `1`.
+3. Enable `Dismiss stale pull request approvals when new commits are pushed`.
+4. Enable `Require review from Code Owners`.
+5. Enable `Require conversation resolution before merging`.
+6. Enable `Require status checks to pass before merging` and add:
+   - `lint`
+   - `build`
+7. Enable `Require branches to be up to date before merging`.
+8. Disable direct pushes (do not grant bypass except emergency admins).
+9. Disable force pushes.
+10. Disable branch deletion.
+
+## Merge Queue (Preferred)
+If your GitHub plan supports merge queue:
+
+1. Enable `Require merge queue` for `main`.
+2. Keep required checks as `lint` and `build` initially.
+3. Start with a conservative queue strategy (small batches, low parallelism).
+4. Add `merge_group` workflow trigger support (already included in `.github/workflows/ci-gate.yml`).
+
+## Fallback if Merge Queue Is Unavailable
+Use pre-merge combined checks:
+
+1. Keep `Require branches to be up to date before merging` enabled.
+2. Keep PR checks running on GitHub's synthetic merge commit (default `pull_request` behavior).
+3. Require a fresh green run after rebasing/cherry-picking onto latest `main`.
+
+## Verification Steps
+1. Open a small PR.
+2. Confirm `lint` and `build` run automatically.
+3. Confirm merge is blocked while checks are failing.
+4. Confirm merge is allowed only after all required checks are green.


### PR DESCRIPTION
## Why
This PR establishes a fast, low-friction merge gate so `main` can become the single controlled integration path under multi-agent parallel development.

## What
- Add minimal CI workflow with required-ready checks:
  - `lint` (Ruff parser/syntax safety subset)
  - `build` (Python compile check)
- Add PR template with required sections:
  - scope, changed files, acceptance criteria, test evidence, risks
- Add repository guardrail docs and ownership:
  - `docs/agent_rules.md`
  - `docs/governance/branch-protection.md`
  - `CODEOWNERS`
  - `CONTRIBUTING.md`

## Validation
- `ruff check dare_framework tests --select E9,F63,F7`
- `python -m compileall -q dare_framework tests`

## Notes
- This is intentionally phase-1 strictness: stable + fast first, then tighten in follow-up PRs.