### PR TITLE
ci(gates): phase-3 risk matrix + skip/lockfile collaboration guards

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,10 +28,16 @@ If this PR is a large diff (>300 changed lines), explain why split PRs are not p
 - Evidence/output summary:
   - `...`
 
+If this PR changes high-risk runtime paths (auth/concurrency/execution control), include `risk-matrix` evidence.
+
 ## Risk and Rollback
 - Risk level: Low / Medium / High
 - Main risk points:
 - Rollback plan:
+
+## Dependency and Lockfile Changes
+- Lockfile changed in this PR: [ ] Yes [ ] No
+- If yes, manifest updated in same PR (`requirements.txt`/`pyproject.toml`/`package.json`): [ ] Yes [ ] No [ ] N/A
 
 ## Agent Rules Checklist (required)
 Reference: `docs/agent_rules.md`

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -69,3 +69,48 @@ jobs:
 
       - name: Run smoke tests
         run: pytest -q tests/smoke -m smoke
+
+  risk-matrix:
+    name: risk-matrix
+    runs-on: ubuntu-latest
+    needs: [lint, build]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install risk-matrix dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest pytest-asyncio langchain-openai langchain-core httpx starlette uvicorn
+
+      - name: Run risk matrix
+        run: ./scripts/ci/run_risk_matrix.sh
+
+  test-skip-guard:
+    name: test-skip-guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check new skip/only markers
+        run: ./scripts/ci/check_test_skip_markers.sh
+
+  lockfile-policy:
+    name: lockfile-policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check lockfile update policy
+        run: ./scripts/ci/check_lockfile_policy.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,12 +19,31 @@ These checks are designed to be fast and low-friction first. We will tighten the
 - Current mode: non-blocking (`continue-on-error`), used as signal collection before becoming required.
 - Scope: `tests/smoke/` only, deterministic checks with no external model calls.
 
+## Risk Matrix (phase-3)
+- CI job: `risk-matrix`
+- Current scope:
+  - `tests/unit/test_a2a.py` (auth gate path)
+  - `tests/unit/test_transport_channel.py` (concurrency/backpressure path)
+  - `tests/unit/test_execution_control.py` (execution control and risk path)
+
+## Skip/Only Guard
+- CI job: `test-skip-guard`
+- Any newly added `skip/skipif/xfail/only` marker in changed Python lines fails this check.
+- If a temporary skip is unavoidable, document why in PR risk section and get explicit review.
+
+## Lockfile Policy
+- CI job: `lockfile-policy`
+- If lockfiles change (`poetry.lock`, `Pipfile.lock`, `uv.lock`, `requirements.lock`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`), the dependency manifest must also change in the same PR (`requirements.txt`, `pyproject.toml`, or `package.json`).
+
 ## Run Checks Locally
 ```bash
 python -m pip install -r requirements.txt
 ruff check dare_framework tests --select E9,F63,F7
 python -m compileall -q dare_framework tests
 pytest -q tests/smoke -m smoke
+./scripts/ci/run_risk_matrix.sh
+./scripts/ci/check_test_skip_markers.sh
+./scripts/ci/check_lockfile_policy.sh
 ```
 
 ## Team Agent Rules

--- a/docs/governance/branch-protection.md
+++ b/docs/governance/branch-protection.md
@@ -26,6 +26,11 @@ If your GitHub plan supports merge queue:
 3. Start with a conservative queue strategy (small batches, low parallelism).
 4. Add `merge_group` workflow trigger support (already included in `.github/workflows/ci-gate.yml`).
 
+## Phase Rollout for Required Checks
+- Phase 1 (now, required): `lint`, `build`
+- Phase 2 (observe first, then required): `smoke-tests`
+- Phase 3 (after 1-2 stable weeks, then required): `risk-matrix`, `test-skip-guard`, `lockfile-policy`
+
 ## Fallback if Merge Queue Is Unavailable
 Use pre-merge combined checks:
 

--- a/scripts/ci/check_lockfile_policy.sh
+++ b/scripts/ci/check_lockfile_policy.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIFF_RANGE=""
+if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+  git fetch --no-tags --depth=1 origin "${GITHUB_BASE_REF}" >/dev/null 2>&1 || true
+  if git merge-base "origin/${GITHUB_BASE_REF}" HEAD >/dev/null 2>&1; then
+    DIFF_RANGE="origin/${GITHUB_BASE_REF}...HEAD"
+  else
+    echo "No merge base with origin/${GITHUB_BASE_REF}; fallback to previous commit diff."
+  fi
+fi
+
+if [[ -z "${DIFF_RANGE}" ]]; then
+  if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    DIFF_RANGE="HEAD~1...HEAD"
+  else
+    echo "No comparable base commit found; skipping lockfile policy check."
+    exit 0
+  fi
+fi
+
+CHANGED_FILES="$(git diff --name-only "${DIFF_RANGE}")"
+if [[ -z "${CHANGED_FILES}" ]]; then
+  echo "No changed files; lockfile policy check skipped."
+  exit 0
+fi
+
+LOCK_PATTERN='(^|/)(poetry\.lock|Pipfile\.lock|uv\.lock|requirements\.lock|package-lock\.json|pnpm-lock\.yaml|yarn\.lock)$'
+if ! printf '%s\n' "${CHANGED_FILES}" | rg -q "${LOCK_PATTERN}"; then
+  echo "No lockfile changes detected."
+  exit 0
+fi
+
+if printf '%s\n' "${CHANGED_FILES}" | rg -q '(^|/)(requirements\.txt|pyproject\.toml|package\.json)$'; then
+  echo "Lockfile and dependency manifest changed together."
+  exit 0
+fi
+
+echo "Lockfile changed without manifest update (requirements.txt/pyproject.toml/package.json)."
+echo "Please update dependency manifest in the same PR or split the lockfile update."
+exit 1

--- a/scripts/ci/check_test_skip_markers.sh
+++ b/scripts/ci/check_test_skip_markers.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIFF_RANGE=""
+if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+  git fetch --no-tags --depth=1 origin "${GITHUB_BASE_REF}" >/dev/null 2>&1 || true
+  if git merge-base "origin/${GITHUB_BASE_REF}" HEAD >/dev/null 2>&1; then
+    DIFF_RANGE="origin/${GITHUB_BASE_REF}...HEAD"
+  else
+    echo "No merge base with origin/${GITHUB_BASE_REF}; fallback to previous commit diff."
+  fi
+fi
+
+if [[ -z "${DIFF_RANGE}" ]]; then
+  if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    DIFF_RANGE="HEAD~1...HEAD"
+  else
+    echo "No comparable base commit found; skipping skip-marker check."
+    exit 0
+  fi
+fi
+
+PATTERN='^\+[^+].*(pytest\.mark\.(skip|skipif|xfail)|\.skip\(|\.only\()'
+if git diff -U0 "${DIFF_RANGE}" -- '*.py' | rg -n "${PATTERN}"; then
+  echo
+  echo "Detected newly added skip/only/xfail markers in changed Python lines."
+  echo "Please justify in PR risk section and get explicit reviewer approval."
+  exit 1
+fi
+
+echo "No newly added skip/only/xfail markers detected."

--- a/scripts/ci/run_risk_matrix.sh
+++ b/scripts/ci/run_risk_matrix.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep this suite small and stable: auth, channel concurrency/backpressure,
+# and execution-control behavior are the highest-leverage regression sentinels.
+pytest -q \
+  tests/unit/test_a2a.py \
+  tests/unit/test_transport_channel.py \
+  tests/unit/test_execution_control.py


### PR DESCRIPTION
## Why
With multiple parallel agent PRs, we need merge-time guardrails that surface high-risk regressions and policy violations before `main` is affected.

## What
- Add risk regression matrix script:
  - `scripts/ci/run_risk_matrix.sh`
  - Covers auth path (`test_a2a`), transport backpressure/concurrency (`test_transport_channel`), execution controls (`test_execution_control`)
- Add anti-silent-regression policy checks:
  - `scripts/ci/check_test_skip_markers.sh` (fails on newly introduced skip/only/xfail markers)
  - `scripts/ci/check_lockfile_policy.sh` (enforces lockfile+manifest consistency)
- Wire CI jobs:
  - `risk-matrix`
  - `test-skip-guard`
  - `lockfile-policy`
- Update docs/template:
  - governance phase rollout guidance
  - PR template risk/lockfile disclosure sections

## Validation
- `./scripts/ci/run_risk_matrix.sh` (40 passed)
- `GITHUB_BASE_REF=main ./scripts/ci/check_test_skip_markers.sh`
- `GITHUB_BASE_REF=main ./scripts/ci/check_lockfile_policy.sh`

## Notes
- Guard scripts include fallback diff logic to stay stable even when upstream branches are force-updated.