### PR TITLE
ci(main-guard): free-tier direct-push guard for main

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -1,0 +1,164 @@
+name: main-guard
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  # Keep every main push incident run for audit trail; do not cancel in progress.
+  group: main-guard-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  enforce-main-pr-only:
+    name: enforce-main-pr-only
+    runs-on: ubuntu-latest
+    env:
+      MAIN_GUARD_MODE: ${{ vars.MAIN_GUARD_MODE }}
+      MAIN_GUARD_ALLOW_ACTORS: ${{ vars.MAIN_GUARD_ALLOW_ACTORS }}
+      MAIN_GUARD_ALLOW_MARKER: ${{ vars.MAIN_GUARD_ALLOW_MARKER }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Classify main push
+        id: classify
+        run: |
+          python scripts/ci/main_guard.py \
+            --event "$GITHUB_EVENT_PATH" \
+            --repository "$GITHUB_REPOSITORY" \
+            --token "${{ secrets.GITHUB_TOKEN }}" \
+            --allow-actors "${MAIN_GUARD_ALLOW_ACTORS:-}" \
+            --allow-marker "${MAIN_GUARD_ALLOW_MARKER:-[main-guard:allow-direct-push]}"
+
+      - name: Write run summary
+        run: |
+          {
+            echo "## Main Guard Result"
+            echo "- Direct push incident: \`${{ steps.classify.outputs.is_direct_push }}\`"
+            echo "- Decision reason: \`${{ steps.classify.outputs.reason }}\`"
+            echo "- Pushed commits: \`${{ steps.classify.outputs.commit_shas }}\`"
+            echo "- Unlinked commits: \`${{ steps.classify.outputs.unlinked_commits }}\`"
+            echo "- Associated PR numbers: \`${{ steps.classify.outputs.associated_pr_numbers }}\`"
+            echo "- Mode: \`${MAIN_GUARD_MODE:-revert-pr}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create incident issue
+        id: incident
+        if: steps.classify.outputs.is_direct_push == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mode="${MAIN_GUARD_MODE:-revert-pr}"
+          title="Main guard incident: direct push on main (${GITHUB_SHA:0:7})"
+          body=$(cat <<EOF
+          ## Main Guard Incident
+
+          Direct push to \`main\` was detected by \`main-guard\`.
+
+          - Repo: \`${GITHUB_REPOSITORY}\`
+          - Actor: \`${GITHUB_ACTOR}\`
+          - Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          - Decision: \`${{ steps.classify.outputs.reason }}\`
+          - Mode: \`${mode}\`
+          - Commit SHA: \`${GITHUB_SHA}\`
+          - Unlinked commits: \`${{ steps.classify.outputs.unlinked_commits }}\`
+          - Associated PR numbers: \`${{ steps.classify.outputs.associated_pr_numbers }}\`
+
+          If this was intentional emergency maintenance, include marker \`[main-guard:allow-direct-push]\` in commit message and add a postmortem note.
+          EOF
+          )
+          issue_url=$(gh issue create --title "$title" --body "$body")
+          echo "issue_url=$issue_url" >> "$GITHUB_OUTPUT"
+
+      - name: Create rollback branch and PR
+        id: rollback
+        if: steps.classify.outputs.is_direct_push == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UNLINKED_COMMITS: ${{ steps.classify.outputs.unlinked_commits }}
+        run: |
+          mode="${MAIN_GUARD_MODE:-revert-pr}"
+          if [ "$mode" != "revert-pr" ]; then
+            echo "rollback_pr_url=" >> "$GITHUB_OUTPUT"
+            echo "Skipping rollback PR because MAIN_GUARD_MODE=${mode}."
+            exit 0
+          fi
+
+          if [ -z "$UNLINKED_COMMITS" ]; then
+            echo "rollback_pr_url=" >> "$GITHUB_OUTPUT"
+            echo "No unlinked commits found; skipping rollback PR."
+            exit 0
+          fi
+
+          git config user.name "main-guard[bot]"
+          git config user.email "main-guard[bot]@users.noreply.github.com"
+
+          rollback_branch="auto/main-guard-revert-${GITHUB_RUN_ID}"
+          git switch --create "$rollback_branch"
+
+          reverted_count=0
+          IFS=',' read -r -a commits <<< "$UNLINKED_COMMITS"
+          for sha in "${commits[@]}"; do
+            if [ -z "$sha" ]; then
+              continue
+            fi
+
+            if git revert --no-edit "$sha"; then
+              reverted_count=$((reverted_count + 1))
+            else
+              git revert --abort || true
+              echo "rollback_pr_url=" >> "$GITHUB_OUTPUT"
+              echo "Failed to revert $sha automatically; manual rollback is required."
+              exit 0
+            fi
+          done
+
+          if [ "$reverted_count" -eq 0 ]; then
+            echo "rollback_pr_url=" >> "$GITHUB_OUTPUT"
+            echo "No commits reverted; skipping rollback PR."
+            exit 0
+          fi
+
+          git push origin "$rollback_branch"
+          rollback_pr_url=$(gh pr create \
+            --base main \
+            --head "$rollback_branch" \
+            --title "chore(main-guard): rollback direct push ${GITHUB_SHA:0:7}" \
+            --body "Auto-generated rollback PR for a direct push incident detected by \`main-guard\`.
+
+          - Incident run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          - Unlinked commits reverted: \`${UNLINKED_COMMITS}\`
+          - Detection reason: \`${{ steps.classify.outputs.reason }}\`")
+          echo "rollback_pr_url=$rollback_pr_url" >> "$GITHUB_OUTPUT"
+
+      - name: Add remediation links to summary
+        if: steps.classify.outputs.is_direct_push == 'true'
+        run: |
+          {
+            echo ""
+            echo "## Main Guard Remediation"
+            echo "- Incident issue: \`${{ steps.incident.outputs.issue_url }}\`"
+            echo "- Rollback PR: \`${{ steps.rollback.outputs.rollback_pr_url }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Mark incident as failed gate
+        if: steps.classify.outputs.is_direct_push == 'true'
+        run: |
+          echo "Direct push incident detected and remediation workflow executed."
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,3 +51,19 @@ Read and follow `docs/agent_rules.md` before opening a PR.
 
 ## Governance Setup
 For GitHub branch protection and merge queue settings, follow `docs/governance/branch-protection.md`.
+
+## Free-Tier Main Guard (Direct Push Fallback)
+- Workflow: `.github/workflows/main-guard.yml`
+- Trigger: every `push` to `main`
+- Behavior:
+  - Detect commits on `main` without PR association metadata
+  - Open an incident issue automatically
+  - In `revert-pr` mode, open an automatic rollback PR for unlinked commits
+  - Mark the run as failed for clear red-signal audit trail
+
+### Repository Variables
+- `MAIN_GUARD_MODE`: `revert-pr` (default) or `alert-only`
+- `MAIN_GUARD_ALLOW_ACTORS`: comma-separated actor allowlist for emergency/bot bypass
+- `MAIN_GUARD_ALLOW_MARKER`: commit marker to bypass incident (default `[main-guard:allow-direct-push]`)
+
+Use bypass only for emergency hotfixes and always attach a postmortem note in follow-up PR/issue.

--- a/docs/governance/branch-protection.md
+++ b/docs/governance/branch-protection.md
@@ -38,6 +38,25 @@ Use pre-merge combined checks:
 2. Keep PR checks running on GitHub's synthetic merge commit (default `pull_request` behavior).
 3. Require a fresh green run after rebasing/cherry-picking onto latest `main`.
 
+## Free-Tier Fallback if Branch Protection Is Unavailable
+Use `.github/workflows/main-guard.yml` as an automated guard rail:
+
+1. Detect pushes to `main` where commits have no associated PR metadata.
+2. Open an incident issue automatically with run link and commit context.
+3. In `MAIN_GUARD_MODE=revert-pr`, auto-create a rollback PR that reverts unlinked commits.
+4. Fail the `main-guard` run intentionally so incidents are visible in Actions history.
+
+### Variables (Repository -> Settings -> Secrets and variables -> Actions -> Variables)
+- `MAIN_GUARD_MODE`
+  - `revert-pr`: detect + issue + rollback PR (recommended default)
+  - `alert-only`: detect + issue only
+- `MAIN_GUARD_ALLOW_ACTORS`
+  - Comma-separated pusher names allowed to bypass detection (emergency admins/bots)
+- `MAIN_GUARD_ALLOW_MARKER`
+  - Commit message override marker (default `[main-guard:allow-direct-push]`)
+
+This fallback does not replace native branch protection, but it gives enforceable detection and remediation when plan limits block branch rules.
+
 ## Verification Steps
 1. Open a small PR.
 2. Confirm `lint` and `build` run automatically.

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Scripts package for CI and local automation helpers."""

--- a/scripts/ci/__init__.py
+++ b/scripts/ci/__init__.py
@@ -1,0 +1,1 @@
+"""CI helper scripts package."""

--- a/scripts/ci/main_guard.py
+++ b/scripts/ci/main_guard.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Detect and classify direct pushes to main by PR association metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable
+
+HEX40_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+@dataclass(slots=True)
+class GuardDecision:
+    is_direct_push: bool
+    reason: str
+    commit_shas: list[str]
+    associated_pr_numbers: list[int]
+    unlinked_commits: list[str]
+
+
+def load_event(event_path: Path) -> dict:
+    with event_path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def parse_allow_actors(raw: str) -> set[str]:
+    actors = {item.strip() for item in raw.split(",") if item.strip()}
+    return actors
+
+
+def _is_valid_sha(value: str) -> bool:
+    return bool(HEX40_RE.fullmatch(value.lower()))
+
+
+def collect_commit_shas(event: dict) -> list[str]:
+    # Push payload commits may be truncated; still include "after" SHA for latest commit.
+    shas: list[str] = []
+    seen: set[str] = set()
+
+    for commit in event.get("commits", []):
+        sha = str(commit.get("id", "")).strip().lower()
+        if sha and _is_valid_sha(sha) and sha not in seen:
+            seen.add(sha)
+            shas.append(sha)
+
+    after = str(event.get("after", "")).strip().lower()
+    if after and _is_valid_sha(after) and after not in seen:
+        shas.append(after)
+
+    return shas
+
+
+def has_allow_marker(event: dict, allow_marker: str) -> bool:
+    if not allow_marker:
+        return False
+
+    head_commit = event.get("head_commit") or {}
+    head_msg = str(head_commit.get("message", ""))
+    if allow_marker in head_msg:
+        return True
+
+    for commit in event.get("commits", []):
+        if allow_marker in str(commit.get("message", "")):
+            return True
+    return False
+
+
+def fetch_associated_pr_numbers(repository: str, commit_sha: str, token: str) -> list[int] | None:
+    url = f"https://api.github.com/repos/{repository}/commits/{commit_sha}/pulls"
+    request = urllib.request.Request(
+        url=url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "main-guard",
+        },
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError:
+        return None
+    except urllib.error.URLError:
+        return None
+
+    numbers: list[int] = []
+    for item in payload:
+        number = item.get("number")
+        if isinstance(number, int):
+            numbers.append(number)
+    return numbers
+
+
+def evaluate_push_event(
+    *,
+    event: dict,
+    repository: str,
+    token: str,
+    allow_actors: set[str],
+    allow_marker: str,
+    fetch_pr_numbers: Callable[[str, str, str], list[int] | None],
+) -> GuardDecision:
+    ref = str(event.get("ref", ""))
+    if ref != "refs/heads/main":
+        return GuardDecision(
+            is_direct_push=False,
+            reason="Ignoring non-main push ref.",
+            commit_shas=[],
+            associated_pr_numbers=[],
+            unlinked_commits=[],
+        )
+
+    if bool(event.get("deleted")):
+        return GuardDecision(
+            is_direct_push=False,
+            reason="Ignoring deleted ref event.",
+            commit_shas=[],
+            associated_pr_numbers=[],
+            unlinked_commits=[],
+        )
+
+    actor = str((event.get("pusher") or {}).get("name", "")).strip()
+    if actor and actor in allow_actors:
+        return GuardDecision(
+            is_direct_push=False,
+            reason=f"Ignoring allowlisted actor: {actor}.",
+            commit_shas=[],
+            associated_pr_numbers=[],
+            unlinked_commits=[],
+        )
+
+    if has_allow_marker(event, allow_marker):
+        return GuardDecision(
+            is_direct_push=False,
+            reason=f"Ignoring push due to allow marker: {allow_marker}.",
+            commit_shas=[],
+            associated_pr_numbers=[],
+            unlinked_commits=[],
+        )
+
+    commit_shas = collect_commit_shas(event)
+    if not commit_shas:
+        return GuardDecision(
+            is_direct_push=False,
+            reason="No commit SHAs found in push payload.",
+            commit_shas=[],
+            associated_pr_numbers=[],
+            unlinked_commits=[],
+        )
+
+    associated_pr_numbers: set[int] = set()
+    unlinked_commits: list[str] = []
+    lookup_failed_commits: list[str] = []
+    for sha in commit_shas:
+        pr_numbers = fetch_pr_numbers(repository, sha, token)
+        if pr_numbers is None:
+            lookup_failed_commits.append(sha)
+        elif pr_numbers:
+            associated_pr_numbers.update(pr_numbers)
+        else:
+            unlinked_commits.append(sha)
+
+    if lookup_failed_commits:
+        return GuardDecision(
+            is_direct_push=False,
+            reason=(
+                "Skipping enforcement because commit->PR lookup failed for at least one commit: "
+                + ",".join(lookup_failed_commits)
+            ),
+            commit_shas=commit_shas,
+            associated_pr_numbers=sorted(associated_pr_numbers),
+            unlinked_commits=[],
+        )
+
+    if unlinked_commits:
+        return GuardDecision(
+            is_direct_push=True,
+            reason=(
+                f"Detected {len(unlinked_commits)} commit(s) on main without associated PR metadata."
+            ),
+            commit_shas=commit_shas,
+            associated_pr_numbers=sorted(associated_pr_numbers),
+            unlinked_commits=unlinked_commits,
+        )
+
+    return GuardDecision(
+        is_direct_push=False,
+        reason="All pushed commits are associated with at least one PR.",
+        commit_shas=commit_shas,
+        associated_pr_numbers=sorted(associated_pr_numbers),
+        unlinked_commits=[],
+    )
+
+
+def _write_output(name: str, value: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+
+    with open(output_path, "a", encoding="utf-8") as fh:
+        fh.write(f"{name}={value}\n")
+
+
+def _comma_join(values: list[str]) -> str:
+    return ",".join(values)
+
+
+def _int_join(values: list[int]) -> str:
+    return ",".join(str(item) for item in values)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event", required=True, type=Path, help="Path to GitHub event payload JSON.")
+    parser.add_argument("--repository", required=True, help="owner/repo")
+    parser.add_argument("--token", default="", help="GitHub token for commit->PR lookup.")
+    parser.add_argument(
+        "--allow-actors",
+        default="",
+        help="Comma-separated allowlist of pusher actor names, e.g. release-bot,admin-user",
+    )
+    parser.add_argument(
+        "--allow-marker",
+        default="[main-guard:allow-direct-push]",
+        help="Commit message marker that bypasses direct-push incident handling.",
+    )
+    args = parser.parse_args()
+
+    event = load_event(args.event)
+    decision = evaluate_push_event(
+        event=event,
+        repository=args.repository,
+        token=args.token,
+        allow_actors=parse_allow_actors(args.allow_actors),
+        allow_marker=args.allow_marker,
+        fetch_pr_numbers=fetch_associated_pr_numbers,
+    )
+
+    _write_output("is_direct_push", "true" if decision.is_direct_push else "false")
+    _write_output("reason", decision.reason)
+    _write_output("commit_shas", _comma_join(decision.commit_shas))
+    _write_output("unlinked_commits", _comma_join(decision.unlinked_commits))
+    _write_output("associated_pr_numbers", _int_join(decision.associated_pr_numbers))
+
+    print(json.dumps(asdict(decision), ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_main_guard.py
+++ b/tests/unit/test_main_guard.py
@@ -1,0 +1,149 @@
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.main_guard import evaluate_push_event, load_event
+
+
+def _base_event() -> dict:
+    return {
+        "ref": "refs/heads/main",
+        "after": "a" * 40,
+        "pusher": {"name": "dev-user"},
+        "commits": [
+            {"id": "a" * 40, "message": "normal commit"},
+        ],
+        "head_commit": {"id": "a" * 40, "message": "normal commit"},
+    }
+
+
+def test_load_event_reads_json_payload() -> None:
+    payload = _base_event()
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        event_path = Path(tmp_dir) / "event.json"
+        event_path.write_text(json.dumps(payload), encoding="utf-8")
+        assert load_event(event_path) == payload
+
+
+def test_evaluate_returns_non_direct_for_non_main_ref() -> None:
+    event = _base_event()
+    event["ref"] = "refs/heads/feature/a"
+
+    result = evaluate_push_event(
+        event=event,
+        repository="owner/repo",
+        token="token",
+        allow_actors=set(),
+        allow_marker="[main-guard:allow-direct-push]",
+        fetch_pr_numbers=lambda *_args, **_kwargs: [12],
+    )
+
+    assert result.is_direct_push is False
+    assert "non-main" in result.reason
+
+
+def test_evaluate_returns_non_direct_for_allowlisted_actor() -> None:
+    event = _base_event()
+
+    result = evaluate_push_event(
+        event=event,
+        repository="owner/repo",
+        token="token",
+        allow_actors={"dev-user"},
+        allow_marker="[main-guard:allow-direct-push]",
+        fetch_pr_numbers=lambda *_args, **_kwargs: pytest.fail(
+            "fetch_pr_numbers should not run for allowlisted actor"
+        ),
+    )
+
+    assert result.is_direct_push is False
+    assert "allowlisted actor" in result.reason
+
+
+def test_evaluate_returns_non_direct_for_allow_marker() -> None:
+    event = _base_event()
+    event["head_commit"]["message"] = "hotfix [main-guard:allow-direct-push]"
+
+    result = evaluate_push_event(
+        event=event,
+        repository="owner/repo",
+        token="token",
+        allow_actors=set(),
+        allow_marker="[main-guard:allow-direct-push]",
+        fetch_pr_numbers=lambda *_args, **_kwargs: pytest.fail(
+            "fetch_pr_numbers should not run for allow marker"
+        ),
+    )
+
+    assert result.is_direct_push is False
+    assert "allow marker" in result.reason
+
+
+def test_evaluate_returns_non_direct_when_all_commits_have_pr() -> None:
+    event = _base_event()
+    event["commits"] = [
+        {"id": "a" * 40, "message": "commit A"},
+        {"id": "b" * 40, "message": "commit B"},
+    ]
+    event["after"] = "b" * 40
+    fetched = []
+
+    def _fetch(_repo: str, sha: str, _token: str) -> list[int]:
+        fetched.append(sha)
+        return [42]
+
+    result = evaluate_push_event(
+        event=event,
+        repository="owner/repo",
+        token="token",
+        allow_actors=set(),
+        allow_marker="[main-guard:allow-direct-push]",
+        fetch_pr_numbers=_fetch,
+    )
+
+    assert fetched == ["a" * 40, "b" * 40]
+    assert result.is_direct_push is False
+    assert result.unlinked_commits == []
+
+
+def test_evaluate_returns_direct_push_when_unlinked_commit_found() -> None:
+    event = _base_event()
+    event["commits"] = [
+        {"id": "a" * 40, "message": "commit A"},
+        {"id": "b" * 40, "message": "commit B"},
+    ]
+    event["after"] = "b" * 40
+
+    def _fetch(_repo: str, sha: str, _token: str) -> list[int]:
+        return [] if sha == "b" * 40 else [9]
+
+    result = evaluate_push_event(
+        event=event,
+        repository="owner/repo",
+        token="token",
+        allow_actors=set(),
+        allow_marker="[main-guard:allow-direct-push]",
+        fetch_pr_numbers=_fetch,
+    )
+
+    assert result.is_direct_push is True
+    assert result.unlinked_commits == ["b" * 40]
+    assert "without associated PR" in result.reason
+
+
+def test_evaluate_skips_enforcement_when_lookup_fails() -> None:
+    event = _base_event()
+
+    result = evaluate_push_event(
+        event=event,
+        repository="owner/repo",
+        token="token",
+        allow_actors=set(),
+        allow_marker="[main-guard:allow-direct-push]",
+        fetch_pr_numbers=lambda *_args, **_kwargs: None,
+    )
+
+    assert result.is_direct_push is False
+    assert "lookup failed" in result.reason


### PR DESCRIPTION
## Summary
- add `.github/workflows/main-guard.yml` as free-tier fallback guard for `main`
- detect direct push by checking commit-to-PR association metadata
- auto-create incident issue and optional rollback PR (`MAIN_GUARD_MODE=revert-pr`)

## Why
Native branch protection is currently blocked by plan limits. We still need enforceable convergence on `main` under high-speed multi-agent parallel delivery.

## Scope
- workflow + CI helper script + unit tests + governance docs
- no runtime feature refactor

## Key Files
- `.github/workflows/main-guard.yml`
- `scripts/ci/main_guard.py`
- `tests/unit/test_main_guard.py`
- `CONTRIBUTING.md`
- `docs/governance/branch-protection.md`

## Test Evidence
- `pytest -q tests/unit/test_main_guard.py` (7 passed)
- `ruff check scripts/ci/main_guard.py tests/unit/test_main_guard.py` (clean)
- local script dry-run with synthetic push payload (JSON output valid)

## Ops Notes
Repository variables for tuning behavior:
- `MAIN_GUARD_MODE`: `revert-pr` (default) or `alert-only`
- `MAIN_GUARD_ALLOW_ACTORS`: comma-separated emergency/bot allowlist
- `MAIN_GUARD_ALLOW_MARKER`: bypass marker (default `[main-guard:allow-direct-push]`)
