### PR TITLE
Add approval pending transport events and poll controls

### DIFF
--- a/dare_framework/agent/base_agent.py
+++ b/dare_framework/agent/base_agent.py
@@ -192,7 +192,11 @@ class BaseAgent(IAgent, IAgentOrchestration, ABC):
                         continue
 
                     self._in_flight_task = asyncio.create_task(
-                        self._execute_polled_message(envelope.payload, channel=channel),
+                        self._execute_polled_message(
+                            envelope.payload,
+                            channel=channel,
+                            envelope_id=envelope.id,
+                        ),
                     )
                     try:
                         await self._in_flight_task
@@ -212,11 +216,17 @@ class BaseAgent(IAgent, IAgentOrchestration, ABC):
     async def _stop_components(self) -> None:
         """Hook for subclasses to stop internal components."""
 
-    async def _execute_polled_message(self, task: str, *, channel: AgentChannel) -> None:
+    async def _execute_polled_message(
+        self,
+        task: str,
+        *,
+        channel: AgentChannel,
+        envelope_id: str | None,
+    ) -> None:
         """Execute one polled message and send response envelope through channel."""
         result = await self.execute(task, transport=channel)
         result = self._with_normalized_output_text(result)
-        await self._send_transport_result(result, task=task, transport=channel)
+        await self._send_transport_result(result, task=task, transport=channel, reply_to=envelope_id)
 
     def _with_normalized_output_text(self, result: RunResult) -> RunResult:
         """Ensure RunResult.output_text is filled for downstream consumers."""
@@ -248,12 +258,14 @@ class BaseAgent(IAgent, IAgentOrchestration, ABC):
         *,
         task: str | None = None,
         transport: AgentChannel | None = None,
+        reply_to: str | None = None,
     ) -> None:
         channel = transport
         if channel is None:
             return
         envelope = TransportEnvelope(
             id=new_envelope_id(),
+            reply_to=reply_to,
             payload={
                 **build_success_payload(
                     kind="message",

--- a/dare_framework/agent/dare_agent.py
+++ b/dare_framework/agent/dare_agent.py
@@ -51,6 +51,11 @@ from dare_framework.tool._internal.control.approval_manager import (
     ApprovalEvaluationStatus,
 )
 from dare_framework.tool.types import CapabilityKind
+from dare_framework.transport.interaction.payloads import (
+    build_approval_pending_payload,
+    build_approval_resolved_payload,
+)
+from dare_framework.transport.types import TransportEnvelope, new_envelope_id
 
 
 @dataclass
@@ -196,6 +201,7 @@ class DareAgent(BaseAgent):
 
         # Runtime state (set during execution)
         self._session_state: SessionState | None = None
+        self._active_transport: AgentChannel | None = None
         self._token_usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "cached_tokens": 0}
 
     @property
@@ -220,7 +226,8 @@ class DareAgent(BaseAgent):
         transport: AgentChannel | None = None,
     ) -> RunResult:
         """Execute a task with automatic mode selection."""
-        _ = transport
+        previous_transport = self._active_transport
+        self._active_transport = transport
         if isinstance(task, Task):
             task_obj = task
         else:
@@ -252,6 +259,7 @@ class DareAgent(BaseAgent):
             error = exc
             raise
         finally:
+            self._active_transport = previous_transport
             duration_ms = (time.perf_counter() - start_time) * 1000.0
             errors: list[str] = []
             if result is not None and result.errors:
@@ -1038,6 +1046,12 @@ class DareAgent(BaseAgent):
             return False, "tool invocation requires approval"
 
         request_id = evaluation.request.request_id
+        await self._emit_approval_pending_message(
+            request=evaluation.request.to_dict(),
+            capability_id=capability_id,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+        )
         await self._log_event(
             "exec.waiting_human",
             {
@@ -1064,6 +1078,13 @@ class DareAgent(BaseAgent):
                 "source": "pending_request",
                 "request_id": request_id,
             },
+        )
+        await self._emit_approval_resolved_message(
+            request_id=request_id,
+            decision=decision.value,
+            capability_id=capability_id,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
         )
         if decision == ApprovalDecision.ALLOW:
             return True, None
@@ -1300,6 +1321,53 @@ class DareAgent(BaseAgent):
                 await self._extension_point.emit(phase, enriched)
             except Exception:
                 pass
+
+    async def _emit_approval_pending_message(
+        self,
+        *,
+        request: dict[str, Any],
+        capability_id: str,
+        tool_name: str,
+        tool_call_id: str,
+    ) -> None:
+        payload = build_approval_pending_payload(
+            request=request,
+            capability_id=capability_id,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+        )
+        await self._send_transport_payload(payload)
+
+    async def _emit_approval_resolved_message(
+        self,
+        *,
+        request_id: str,
+        decision: str,
+        capability_id: str,
+        tool_name: str,
+        tool_call_id: str,
+    ) -> None:
+        payload = build_approval_resolved_payload(
+            request_id=request_id,
+            decision=decision,
+            capability_id=capability_id,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+        )
+        await self._send_transport_payload(payload)
+
+    async def _send_transport_payload(self, payload: dict[str, Any]) -> None:
+        channel = self._active_transport
+        if channel is None:
+            return
+        envelope = TransportEnvelope(
+            id=new_envelope_id(),
+            payload=payload,
+        )
+        try:
+            await channel.send(envelope)
+        except Exception:
+            self._logger.exception("agent approval transport send failed")
 
     def _record_token_usage(self, usage: dict[str, Any] | None) -> None:
         if not usage:

--- a/dare_framework/tool/_internal/control/approval_manager.py
+++ b/dare_framework/tool/_internal/control/approval_manager.py
@@ -217,6 +217,7 @@ class ToolApprovalManager:
         self._pending_by_id: dict[str, _PendingApproval] = {}
         self._pending_by_fingerprint: dict[str, _PendingApproval] = {}
         self._resolved_by_id: dict[str, ApprovalDecision] = {}
+        self._pending_available = asyncio.Event()
         self._lock = asyncio.Lock()
 
     @classmethod
@@ -226,7 +227,35 @@ class ToolApprovalManager:
         return cls(workspace_store=workspace_store, user_store=user_store)
 
     def list_pending(self) -> list[PendingApprovalRequest]:
-        return [entry.request for entry in self._pending_by_id.values()]
+        pending = [entry.request for entry in self._pending_by_id.values()]
+        pending.sort(key=lambda item: (item.created_at, item.request_id))
+        return pending
+
+    async def poll_pending(self, *, timeout_seconds: float | None = None) -> PendingApprovalRequest | None:
+        """Return the oldest pending approval request, optionally waiting for one."""
+        if timeout_seconds is not None and timeout_seconds < 0:
+            raise ValueError("timeout_seconds must be >= 0")
+
+        loop = asyncio.get_running_loop()
+        deadline = None if timeout_seconds is None else loop.time() + timeout_seconds
+        while True:
+            async with self._lock:
+                request = self._oldest_pending_locked()
+                if request is not None:
+                    return request
+                wait_event = self._pending_available
+
+            if deadline is None:
+                await wait_event.wait()
+                continue
+
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return None
+            try:
+                await asyncio.wait_for(wait_event.wait(), timeout=remaining)
+            except asyncio.TimeoutError:
+                return None
 
     def list_rules(self) -> list[ApprovalRule]:
         combined = [
@@ -286,6 +315,7 @@ class ToolApprovalManager:
                 existing = _PendingApproval(request=request, fingerprint=fingerprint)
                 self._pending_by_fingerprint[fingerprint] = existing
                 self._pending_by_id[request.request_id] = existing
+                self._pending_available.set()
 
             return ApprovalEvaluation(
                 status=ApprovalEvaluationStatus.PENDING,
@@ -389,6 +419,8 @@ class ToolApprovalManager:
             self._resolved_by_id[request_id] = decision
             self._pending_by_id.pop(request_id, None)
             self._pending_by_fingerprint.pop(pending.fingerprint, None)
+            if not self._pending_by_id:
+                self._pending_available.clear()
             return rule
 
     def _append_rule(self, rule: ApprovalRule) -> None:
@@ -476,6 +508,15 @@ class ToolApprovalManager:
             if rule.decision == ApprovalDecision.ALLOW:
                 return rule
         return None
+
+    def _oldest_pending_locked(self) -> PendingApprovalRequest | None:
+        if not self._pending_by_id:
+            return None
+        oldest = min(
+            self._pending_by_id.values(),
+            key=lambda item: (item.request.created_at, item.request.request_id),
+        )
+        return oldest.request
 
 
 def _rule_matches(

--- a/dare_framework/tool/action_handler.py
+++ b/dare_framework/tool/action_handler.py
@@ -58,6 +58,7 @@ class ApprovalsActionHandler(IActionHandler):
     def supports(self) -> set[ResourceAction]:
         return {
             ResourceAction.APPROVALS_LIST,
+            ResourceAction.APPROVALS_POLL,
             ResourceAction.APPROVALS_GRANT,
             ResourceAction.APPROVALS_DENY,
             ResourceAction.APPROVALS_REVOKE,
@@ -73,6 +74,11 @@ class ApprovalsActionHandler(IActionHandler):
             pending = [_pending_to_dict(item) for item in self._approval_manager.list_pending()]
             rules = [_rule_to_dict(item) for item in self._approval_manager.list_rules()]
             return {"pending": pending, "rules": rules}
+
+        if action == ResourceAction.APPROVALS_POLL:
+            timeout_seconds = _parse_timeout_seconds(params)
+            request = await self._approval_manager.poll_pending(timeout_seconds=timeout_seconds)
+            return {"request": _pending_to_dict(request) if request is not None else None}
 
         if action == ResourceAction.APPROVALS_GRANT:
             request_id = _require_request_id(params)
@@ -172,6 +178,22 @@ def _optional_matcher_value(raw: Any) -> str | None:
         return None
     text = str(raw).strip()
     return text or None
+
+
+def _parse_timeout_seconds(params: dict[str, Any]) -> float | None:
+    raw_seconds = params.get("timeout_seconds")
+    raw_millis = params.get("timeout_ms")
+    if raw_seconds is not None:
+        value = float(raw_seconds)
+        if value < 0:
+            raise ValueError("timeout_seconds must be >= 0")
+        return value
+    if raw_millis is not None:
+        millis = float(raw_millis)
+        if millis < 0:
+            raise ValueError("timeout_ms must be >= 0")
+        return millis / 1000.0
+    return None
 
 
 __all__ = ["ApprovalsActionHandler", "IToolCatalog", "ToolsActionHandler"]

--- a/dare_framework/transport/_internal/adapters.py
+++ b/dare_framework/transport/_internal/adapters.py
@@ -45,6 +45,22 @@ class StdioClientChannel(ClientChannel):
                         output = resp if resp is not None else payload
                 elif payload_type == "error":
                     output = payload.get("reason") or payload.get("error")
+                elif payload_type == "approval_pending":
+                    resp = payload.get("resp")
+                    request_id = None
+                    if isinstance(resp, dict):
+                        request = resp.get("request")
+                        if isinstance(request, dict):
+                            request_id = request.get("request_id")
+                    output = f"approval pending: request_id={request_id or '?'}"
+                elif payload_type == "approval_resolved":
+                    resp = payload.get("resp")
+                    request_id = None
+                    decision = None
+                    if isinstance(resp, dict):
+                        request_id = resp.get("request_id")
+                        decision = resp.get("decision")
+                    output = f"approval resolved: request_id={request_id or '?'} decision={decision or '?'}"
                 elif payload_type == "hook":
                     output = payload.get("event")
                 else:
@@ -132,6 +148,7 @@ class DirectClientChannel(ClientChannel):
     def __init__(self) -> None:
         self._sender: Sender | None = None
         self._pending: dict[str, asyncio.Future[TransportEnvelope]] = {}
+        self._events: asyncio.Queue[TransportEnvelope] = asyncio.Queue()
 
     def attach_agent_envelope_sender(self, sender: Sender) -> None:
         self._sender = sender
@@ -142,6 +159,8 @@ class DirectClientChannel(ClientChannel):
                 fut = self._pending[msg.reply_to]
                 if not fut.done():
                     fut.set_result(msg)
+                    return
+            await self._events.put(msg)
 
         return recv
 
@@ -166,6 +185,17 @@ class DirectClientChannel(ClientChannel):
             return await asyncio.wait_for(fut, timeout)
         finally:
             self._pending.pop(req.id, None)
+
+    async def poll(self, timeout: float | None = None) -> TransportEnvelope | None:
+        """Poll unsolicited envelopes emitted by the agent channel."""
+        if timeout is not None and timeout < 0:
+            raise ValueError("timeout must be >= 0")
+        if timeout is None:
+            return await self._events.get()
+        try:
+            return await asyncio.wait_for(self._events.get(), timeout)
+        except asyncio.TimeoutError:
+            return None
 
 
 def _default_serialize(msg: TransportEnvelope) -> str:

--- a/dare_framework/transport/interaction/payloads.py
+++ b/dare_framework/transport/interaction/payloads.py
@@ -31,4 +31,55 @@ def build_error_payload(*, kind: str, target: str, code: str, reason: str) -> di
     }
 
 
-__all__ = ["build_success_payload", "build_error_payload"]
+def build_approval_pending_payload(
+    *,
+    request: dict[str, Any],
+    capability_id: str,
+    tool_name: str,
+    tool_call_id: str,
+) -> dict[str, Any]:
+    """Build a transport payload for a pending tool approval request."""
+    return {
+        "type": "approval_pending",
+        "kind": "approval",
+        "target": capability_id,
+        "ok": True,
+        "resp": {
+            "request": request,
+            "capability_id": capability_id,
+            "tool_name": tool_name,
+            "tool_call_id": tool_call_id,
+        },
+    }
+
+
+def build_approval_resolved_payload(
+    *,
+    request_id: str,
+    decision: str,
+    capability_id: str,
+    tool_name: str,
+    tool_call_id: str,
+) -> dict[str, Any]:
+    """Build a transport payload for a resolved tool approval request."""
+    return {
+        "type": "approval_resolved",
+        "kind": "approval",
+        "target": capability_id,
+        "ok": True,
+        "resp": {
+            "request_id": request_id,
+            "decision": decision,
+            "capability_id": capability_id,
+            "tool_name": tool_name,
+            "tool_call_id": tool_call_id,
+        },
+    }
+
+
+__all__ = [
+    "build_success_payload",
+    "build_error_payload",
+    "build_approval_pending_payload",
+    "build_approval_resolved_payload",
+]

--- a/dare_framework/transport/interaction/resource_action.py
+++ b/dare_framework/transport/interaction/resource_action.py
@@ -15,10 +15,13 @@ class ResourceAction(StrEnum):
     ACTIONS_LIST = "actions:list"
     TOOLS_LIST = "tools:list"
     APPROVALS_LIST = "approvals:list"
+    APPROVALS_POLL = "approvals:poll"
     APPROVALS_GRANT = "approvals:grant"
     APPROVALS_DENY = "approvals:deny"
     APPROVALS_REVOKE = "approvals:revoke"
     MCP_LIST = "mcp:list"
+    MCP_RELOAD = "mcp:reload"
+    MCP_SHOW_TOOL = "mcp:show-tool"
     SKILLS_LIST = "skills:list"
     MODEL_GET = "model:get"
 

--- a/docs/guides/Tool_Approval_Memory.md
+++ b/docs/guides/Tool_Approval_Memory.md
@@ -18,6 +18,7 @@
 - 创建逻辑：`ToolApprovalManager.from_paths(workspace_dir=config.workspace_dir, user_dir=config.user_dir)`
 - action 暴露：
   - `approvals:list`
+  - `approvals:poll`
   - `approvals:grant`
   - `approvals:deny`
   - `approvals:revoke`
@@ -107,6 +108,37 @@
 
 输出：`{"rule_id": "...", "removed": true|false}`
 
+### 4.5 `approvals:poll`
+
+用于控制面阻塞等待下一个待审批请求（避免高频 `approvals:list` 轮询）。
+
+可选参数：
+
+- `timeout_seconds` 或 `timeout_ms`
+
+输出：
+
+```json
+{
+  "request": {
+    "request_id": "...",
+    "capability_id": "run_command",
+    "...": "..."
+  }
+}
+```
+
+若超时未出现 pending，则 `request=null`。
+
+## 5. Transport 审批事件（推荐）
+
+当 `requires_approval=true` 的工具调用进入 pending 时，runtime 会通过 transport 主动发出：
+
+- `type="approval_pending"`：包含 pending request 详情
+- `type="approval_resolved"`：包含 request_id 与最终 decision（allow/deny）
+
+这允许客户端实现 Codex/Claude Code 风格的“消息流里出现审批卡片”，同时再用 `approvals:grant|deny` 完成决策。
+
 ## 5. 接入示例（推荐）
 
 完整可运行示例见：`examples/07-tool-approval-memory/main.py`
@@ -123,6 +155,7 @@
 `examples/05-dare-coding-agent-enhanced/cli.py` 与 `examples/06-dare-coding-agent-mcp/cli.py` 都支持：
 
 - `/approvals list`
+- `/approvals poll [timeout_ms=30000]`
 - `/approvals grant <request_id> [scope=workspace] [matcher=exact_params] [matcher_value=...]`
 - `/approvals deny <request_id> [scope=once] [matcher=exact_params] [matcher_value=...]`
 - `/approvals revoke <rule_id>`

--- a/examples/05-dare-coding-agent-enhanced/README.md
+++ b/examples/05-dare-coding-agent-enhanced/README.md
@@ -29,6 +29,7 @@ python main.py
 - `/reject`：取消当前计划
 - `/status`：查看状态
 - `/approvals list`：查看待审批请求与当前审批规则
+- `/approvals poll [timeout_ms=30000]`：阻塞等待下一个待审批请求（无请求则超时返回）
 - `/approvals grant <request_id> [scope=workspace] [matcher=exact_params] [matcher_value=...]`：批准请求并可写入规则
 - `/approvals deny <request_id> [scope=once] [matcher=exact_params] [matcher_value=...]`：拒绝请求并可写入规则
 - `/approvals revoke <rule_id>`：撤销审批规则
@@ -43,7 +44,7 @@ python main.py
 ### 审批操作建议流程（交互模式）
 
 1. 先执行一个可能触发高风险工具的任务（如会调用 `run_command`）。
-2. 用 `/approvals list` 查看 `pending` 里的 `request_id`。
+2. 用 `/approvals poll timeout_ms=30000`（或 `/approvals list`）拿到 `request_id`。
 3. 按需执行：
    - `/approvals grant <request_id> scope=workspace matcher=exact_params`
    - `/approvals deny <request_id> scope=once matcher=exact_params`

--- a/examples/05-dare-coding-agent-enhanced/cli.py
+++ b/examples/05-dare-coding-agent-enhanced/cli.py
@@ -472,6 +472,7 @@ async def _handle_mcp_command(
 
 def _approvals_usage(display: CLIDisplay) -> None:
     display.info("/approvals list")
+    display.info("/approvals poll [timeout_ms=30000]")
     display.info("/approvals grant <request_id> [scope=workspace] [matcher=exact_params] [matcher_value=...]")
     display.info("/approvals deny <request_id> [scope=once] [matcher=exact_params] [matcher_value=...]")
     display.info("/approvals revoke <rule_id>")
@@ -528,10 +529,25 @@ async def _handle_approvals_command(
     subcommand = args[0].lower()
     try:
         if subcommand == "list":
-            result = await handler.invoke(ResourceAction.APPROVALS_LIST, {})
+            result = await handler.invoke(ResourceAction.APPROVALS_LIST)
             pending = result.get("pending", [])
             rules = result.get("rules", [])
             display.info(f"pending={len(pending)} rules={len(rules)}")
+            print(json.dumps(result, ensure_ascii=False, indent=2), flush=True)
+            return
+
+        if subcommand == "poll":
+            _positional, options = _parse_key_value_args(args[1:])
+            params: dict[str, Any] = {}
+            for key in ("timeout_ms", "timeout_seconds"):
+                if key in options and options[key]:
+                    params[key] = options[key]
+            result = await handler.invoke(ResourceAction.APPROVALS_POLL, **params)
+            request = result.get("request")
+            if isinstance(request, dict):
+                display.info(f"pending request: {request.get('request_id', '?')}")
+            else:
+                display.info("no pending approval request")
             print(json.dumps(result, ensure_ascii=False, indent=2), flush=True)
             return
 
@@ -547,7 +563,7 @@ async def _handle_approvals_command(
                 else ResourceAction.APPROVALS_DENY
             )
             params = _build_approval_action_params(request_id=request_id, trailing_args=args[2:])
-            result = await handler.invoke(action, params)
+            result = await handler.invoke(action, **params)
             display.ok(f"{subcommand} applied: {request_id}")
             print(json.dumps(result, ensure_ascii=False, indent=2), flush=True)
             return
@@ -560,7 +576,7 @@ async def _handle_approvals_command(
             rule_id = args[1]
             result = await handler.invoke(
                 ResourceAction.APPROVALS_REVOKE,
-                {"rule_id": rule_id},
+                rule_id=rule_id,
             )
             if result.get("removed"):
                 display.ok(f"revoked rule: {rule_id}")
@@ -653,7 +669,7 @@ async def run_cli_loop(
             if cmd.type == CommandType.HELP:
                 display.info(
                     "/mode [plan|execute], /approve, /reject, /status, "
-                    "/approvals [list|grant|deny|revoke], /mcp [list|reload|unload], /quit"
+                    "/approvals [list|poll|grant|deny|revoke], /mcp [list|reload|unload], /quit"
                 )
                 continue
             if cmd.type == CommandType.STATUS:

--- a/examples/05-dare-coding-agent-enhanced/demo_script.txt
+++ b/examples/05-dare-coding-agent-enhanced/demo_script.txt
@@ -1,9 +1,11 @@
 # Demo flow: preview plan -> execute -> inspect approval memory
 /status
 /approvals list
+/approvals poll timeout_ms=500
 /mode plan
 Create snake_game.py in Python that prints a startup message.
 /approve
 /status
+/approvals poll timeout_ms=500
 /approvals list
 /quit

--- a/examples/06-dare-coding-agent-mcp/README.md
+++ b/examples/06-dare-coding-agent-mcp/README.md
@@ -69,6 +69,7 @@ MCP server 定义在 `.dare/mcp/local_math.json`：
 - `/reject`：取消待审批计划
 - `/status`：查看当前状态
 - `/approvals list`：查看待审批请求与当前审批规则
+- `/approvals poll [timeout_ms=30000]`：阻塞等待下一个待审批请求（无请求则超时返回）
 - `/approvals grant <request_id> [scope=workspace] [matcher=exact_params] [matcher_value=...]`：批准请求并可写入规则
 - `/approvals deny <request_id> [scope=once] [matcher=exact_params] [matcher_value=...]`：拒绝请求并可写入规则
 - `/approvals revoke <rule_id>`：撤销审批规则
@@ -84,7 +85,7 @@ MCP server 定义在 `.dare/mcp/local_math.json`：
 ### 审批操作建议流程（交互模式）
 
 1. 执行一个可能触发高风险工具的任务（例如会调用 `run_command`）。
-2. 使用 `/approvals list` 获取待审批 `request_id`。
+2. 使用 `/approvals poll timeout_ms=30000`（或 `/approvals list`）获取待审批 `request_id`。
 3. 使用以下命令做决策并继续运行：
    - `/approvals grant <request_id> scope=workspace matcher=exact_params`
    - `/approvals deny <request_id> scope=once matcher=exact_params`

--- a/examples/06-dare-coding-agent-mcp/cli.py
+++ b/examples/06-dare-coding-agent-mcp/cli.py
@@ -579,6 +579,7 @@ async def _handle_mcp_command(
 
 def _approvals_usage(display: CLIDisplay) -> None:
     display.info("/approvals list")
+    display.info("/approvals poll [timeout_ms=30000]")
     display.info("/approvals grant <request_id> [scope=workspace] [matcher=exact_params] [matcher_value=...]")
     display.info("/approvals deny <request_id> [scope=once] [matcher=exact_params] [matcher_value=...]")
     display.info("/approvals revoke <rule_id>")
@@ -635,10 +636,25 @@ async def _handle_approvals_command(
     subcommand = args[0].lower()
     try:
         if subcommand == "list":
-            result = await handler.invoke(ResourceAction.APPROVALS_LIST, {})
+            result = await handler.invoke(ResourceAction.APPROVALS_LIST)
             pending = result.get("pending", [])
             rules = result.get("rules", [])
             display.info(f"pending={len(pending)} rules={len(rules)}")
+            print(json.dumps(result, ensure_ascii=False, indent=2), flush=True)
+            return
+
+        if subcommand == "poll":
+            _positional, options = _parse_key_value_args(args[1:])
+            params: dict[str, Any] = {}
+            for key in ("timeout_ms", "timeout_seconds"):
+                if key in options and options[key]:
+                    params[key] = options[key]
+            result = await handler.invoke(ResourceAction.APPROVALS_POLL, **params)
+            request = result.get("request")
+            if isinstance(request, dict):
+                display.info(f"pending request: {request.get('request_id', '?')}")
+            else:
+                display.info("no pending approval request")
             print(json.dumps(result, ensure_ascii=False, indent=2), flush=True)
             return
 
@@ -654,7 +670,7 @@ async def _handle_approvals_command(
                 else ResourceAction.APPROVALS_DENY
             )
             params = _build_approval_action_params(request_id=request_id, trailing_args=args[2:])
-            result = await handler.invoke(action, params)
+            result = await handler.invoke(action, **params)
             display.ok(f"{subcommand} applied: {request_id}")
             print(json.dumps(result, ensure_ascii=False, indent=2), flush=True)
             return
@@ -667,7 +683,7 @@ async def _handle_approvals_command(
             rule_id = args[1]
             result = await handler.invoke(
                 ResourceAction.APPROVALS_REVOKE,
-                {"rule_id": rule_id},
+                rule_id=rule_id,
             )
             if result.get("removed"):
                 display.ok(f"revoked rule: {rule_id}")
@@ -760,7 +776,7 @@ async def run_cli_loop(
             if cmd.type == CommandType.HELP:
                 display.info(
                     "/mode [plan|execute], /approve, /reject, /status, "
-                    "/approvals [list|grant|deny|revoke], /mcp [list|inspect [tool_name]|reload|unload], /quit"
+                    "/approvals [list|poll|grant|deny|revoke], /mcp [list|inspect [tool_name]|reload|unload], /quit"
                 )
                 continue
             if cmd.type == CommandType.STATUS:

--- a/examples/06-dare-coding-agent-mcp/demo_script.txt
+++ b/examples/06-dare-coding-agent-mcp/demo_script.txt
@@ -1,9 +1,11 @@
 # Demo flow: inspect tools/MCP -> run task -> inspect approvals
 /mcp list
 /approvals list
+/approvals poll timeout_ms=500
 用 local_math:add 工具计算 17 + 25，只返回数字
 /mcp reload
 /approvals list
+/approvals poll timeout_ms=500
 用 local_math:multiply 工具计算 6 * 7，只返回数字
 /status
 /quit

--- a/examples/07-tool-approval-memory/README.md
+++ b/examples/07-tool-approval-memory/README.md
@@ -18,7 +18,8 @@ python main.py
 
 ## 你会看到什么
 
-- 第一次 run：打印 `pending request: ...`，随后调用 `approvals:grant`。
+- 第一次 run：先收到 `approval_pending` 通知并打印 `pending request: ...`，随后调用 `approvals:grant`。
+- 第一次 run 同时演示 `approvals:poll`（控制面阻塞拉取待审批请求）。
 - 第二次 run：`pending_count=0`（自动放行）。
 - 撤销规则后第三次 run：再次出现 `pending request after revoke: ...`。
 - 末尾打印当前 `pending/rules` 状态和规则文件路径。
@@ -29,6 +30,7 @@ python main.py
 - 通道侧：`DirectClientChannel + AgentChannel`
 - 审批 action：
   - `approvals:list`
+  - `approvals:poll`
   - `approvals:grant`
   - `approvals:revoke`
 - 规则持久化路径：

--- a/examples/07-tool-approval-memory/main.py
+++ b/examples/07-tool-approval-memory/main.py
@@ -137,14 +137,44 @@ async def _wait_for_pending_request_id(
 ) -> str:
     deadline = asyncio.get_running_loop().time() + timeout_seconds
     while asyncio.get_running_loop().time() < deadline:
-        listed = await _invoke_action(client, "approvals:list")
-        pending = listed.get("pending", [])
-        if isinstance(pending, list) and pending:
-            first = pending[0]
-            if isinstance(first, dict) and isinstance(first.get("request_id"), str):
-                return first["request_id"]
-        await asyncio.sleep(0.05)
-    raise TimeoutError("pending approval request was not created in time")
+        envelope = await client.poll(timeout=0.2)
+        if envelope is None:
+            continue
+        payload = envelope.payload
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("type") != "approval_pending":
+            continue
+        resp = payload.get("resp")
+        if not isinstance(resp, dict):
+            continue
+        request = resp.get("request")
+        if isinstance(request, dict) and isinstance(request.get("request_id"), str):
+            return request["request_id"]
+    raise TimeoutError("approval_pending event was not received in time")
+
+
+def _new_prompt_envelope(prompt: str) -> TransportEnvelope:
+    return TransportEnvelope(
+        id=new_envelope_id(),
+        kind=EnvelopeKind.MESSAGE,
+        payload=prompt,
+    )
+
+
+def _extract_run_success(response: TransportEnvelope) -> bool:
+    payload = response.payload
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("type") == "error":
+        return False
+    raw_success = payload.get("success")
+    if isinstance(raw_success, bool):
+        return raw_success
+    resp = payload.get("resp")
+    if isinstance(resp, dict):
+        return bool(resp.get("success", False))
+    return False
 
 
 async def main() -> None:
@@ -181,9 +211,12 @@ async def main() -> None:
     await agent.start()
     try:
         print("== 1) first run: pending approval -> grant workspace rule (command_prefix)")
-        first_run = asyncio.create_task(agent("Run the first command"))
+        first_run = asyncio.create_task(client_channel.ask(_new_prompt_envelope("Run the first command"), timeout=30.0))
         first_request_id = await _wait_for_pending_request_id(client_channel)
         print(f"pending request: {first_request_id}")
+
+        polled = await _invoke_action(client_channel, "approvals:poll", timeout_seconds=0.2)
+        print(f"approvals:poll => {json.dumps(polled, ensure_ascii=False)}")
 
         granted = await _invoke_action(
             client_channel,
@@ -195,18 +228,18 @@ async def main() -> None:
         )
         print(json.dumps(granted, indent=2, ensure_ascii=False))
 
-        first_result = await first_run
-        print(f"first run success={first_result.success}, errors={first_result.errors}")
+        first_response = await first_run
+        print(f"first run success={_extract_run_success(first_response)}")
 
         if workspace_rules.exists():
             print("workspace approvals file:")
             print(workspace_rules.read_text(encoding="utf-8"))
 
         print("\n== 2) second run: same command prefix auto-pass (no new pending)")
-        second_result = await agent("Run the second command")
+        second_response = await client_channel.ask(_new_prompt_envelope("Run the second command"), timeout=30.0)
         listed_after_second = await _invoke_action(client_channel, "approvals:list")
         pending_after_second = listed_after_second.get("pending", [])
-        print(f"second run success={second_result.success}, pending_count={len(pending_after_second)}")
+        print(f"second run success={_extract_run_success(second_response)}, pending_count={len(pending_after_second)}")
 
         rule = granted.get("rule")
         if not isinstance(rule, dict) or not isinstance(rule.get("rule_id"), str):
@@ -218,7 +251,7 @@ async def main() -> None:
         print(json.dumps(revoked, indent=2, ensure_ascii=False))
 
         print("\n== 4) third run: pending appears again after revoke")
-        third_run = asyncio.create_task(agent("Run the third command"))
+        third_run = asyncio.create_task(client_channel.ask(_new_prompt_envelope("Run the third command"), timeout=30.0))
         third_request_id = await _wait_for_pending_request_id(client_channel)
         print(f"pending request after revoke: {third_request_id}")
 
@@ -229,8 +262,8 @@ async def main() -> None:
             scope="once",
             matcher="exact_params",
         )
-        third_result = await third_run
-        print(f"third run success={third_result.success}, errors={third_result.errors}")
+        third_response = await third_run
+        print(f"third run success={_extract_run_success(third_response)}")
 
         final_state = await _invoke_action(client_channel, "approvals:list")
         print("\n== Final approval state")

--- a/tests/unit/test_base_agent_transport_contract.py
+++ b/tests/unit/test_base_agent_transport_contract.py
@@ -180,6 +180,7 @@ async def test_transport_loop_accepts_batched_messages_from_poll() -> None:
 
     assert agent.seen_tasks == ["first", "second"]
     assert len(channel._sent) == 2
+    assert [envelope.reply_to for envelope in channel._sent] == ["m1", "m2"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_examples_cli.py
+++ b/tests/unit/test_examples_cli.py
@@ -127,6 +127,13 @@ async def test_handle_approvals_command_list_and_grant(tmp_path: Path) -> None:
     )
     assert any("pending" in msg for level, msg in display.messages if level == "info")
 
+    await cli._handle_approvals_command(  # type: ignore[attr-defined]
+        ["poll", "timeout_ms=10"],
+        agent=_FakeAgent(),
+        display=display,
+    )
+    assert any("pending request:" in msg for level, msg in display.messages if level == "info")
+
     wait_task = asyncio.create_task(manager.wait_for_resolution(request_id))
     await cli._handle_approvals_command(  # type: ignore[attr-defined]
         ["grant", request_id, "scope=workspace", "matcher=exact_params"],

--- a/tests/unit/test_examples_cli_mcp.py
+++ b/tests/unit/test_examples_cli_mcp.py
@@ -95,6 +95,13 @@ async def test_handle_approvals_command_list_and_grant_mcp_cli(tmp_path: Path) -
     )
     assert any("pending" in msg for level, msg in display.messages if level == "info")
 
+    await cli_mcp._handle_approvals_command(  # type: ignore[attr-defined]
+        ["poll", "timeout_ms=10"],
+        agent=_FakeAgent(),
+        display=display,
+    )
+    assert any("pending request:" in msg for level, msg in display.messages if level == "info")
+
     wait_task = asyncio.create_task(manager.wait_for_resolution(request_id))
     await cli_mcp._handle_approvals_command(  # type: ignore[attr-defined]
         ["grant", request_id, "scope=workspace", "matcher=exact_params"],

--- a/tests/unit/test_five_layer_agent.py
+++ b/tests/unit/test_five_layer_agent.py
@@ -144,6 +144,37 @@ class MockConfigProvider:
         return self._config
 
 
+class RecordingTransportChannel:
+    """Transport double that captures outgoing envelopes from direct calls."""
+
+    def __init__(self) -> None:
+        self.sent: list[Any] = []
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def poll(self) -> Any:
+        raise RuntimeError("poll is not used in this test transport")
+
+    async def send(self, msg: Any) -> None:
+        self.sent.append(msg)
+
+    def add_action_handler_dispatcher(self, dispatcher: Any) -> None:
+        _ = dispatcher
+
+    def add_agent_control_handler(self, handler: Any) -> None:
+        _ = handler
+
+    def get_action_handler_dispatcher(self) -> Any:
+        return object()
+
+    def get_agent_control_handler(self) -> Any:
+        return object()
+
+
 def _make_agent(*, model: MockModelAdapter, name: str = "test-agent", **kwargs: Any) -> DareAgent:
     """Build DareAgent test instances with an explicit context by default."""
     context = kwargs.pop("context", Context(config=Config()))
@@ -449,6 +480,68 @@ class TestNoPlannerToolExecution:
         assert second_result.success is True
         assert len(tool_gateway.invoke_calls) == 2
         assert approval_manager.list_pending() == []
+
+    @pytest.mark.asyncio
+    async def test_no_planner_emits_transport_approval_pending_message(self, tmp_path) -> None:
+        capability = CapabilityDescriptor(
+            id="run_command",
+            type=CapabilityType.TOOL,
+            name="run_command",
+            description="Run a shell command.",
+            input_schema={"type": "object", "properties": {"command": {"type": "string"}}},
+            metadata={"requires_approval": True},
+        )
+        tool_gateway = MockToolGateway([capability])
+        approval_manager = ToolApprovalManager(
+            workspace_store=JsonApprovalRuleStore(tmp_path / "workspace" / "approvals.json"),
+            user_store=JsonApprovalRuleStore(tmp_path / "user" / "approvals.json"),
+        )
+        model = MockModelAdapter(
+            [
+                ModelResponse(
+                    content="Running command...",
+                    tool_calls=[{"name": "run_command", "arguments": {"command": "git status --short"}}],
+                ),
+                ModelResponse(content="Done.", tool_calls=[]),
+            ]
+        )
+        agent = _make_agent(
+            name="react-agent-approval-transport",
+            model=model,
+            tool_gateway=tool_gateway,
+            approval_manager=approval_manager,
+        )
+        transport = RecordingTransportChannel()
+
+        run_task = asyncio.create_task(agent("Run git status", transport=transport))
+        request_id: str | None = None
+        for _ in range(100):
+            for envelope in transport.sent:
+                payload = getattr(envelope, "payload", None)
+                if not isinstance(payload, dict):
+                    continue
+                if payload.get("type") != "approval_pending":
+                    continue
+                resp = payload.get("resp")
+                if not isinstance(resp, dict):
+                    continue
+                request = resp.get("request")
+                if isinstance(request, dict) and isinstance(request.get("request_id"), str):
+                    request_id = request["request_id"]
+                    break
+            if request_id is not None:
+                break
+            await asyncio.sleep(0.01)
+        assert request_id is not None
+
+        await approval_manager.grant(
+            request_id,
+            scope=ApprovalScope.ONCE,
+            matcher=ApprovalMatcherKind.EXACT_PARAMS,
+        )
+
+        result = await run_task
+        assert result.success is True
 
 
 # =============================================================================

--- a/tests/unit/test_tool_approval_action_handler.py
+++ b/tests/unit/test_tool_approval_action_handler.py
@@ -76,3 +76,29 @@ async def test_approvals_action_handler_revoke_rule(manager) -> None:
     rule = granted["rule"]
     revoked = await handler.invoke(ResourceAction.APPROVALS_REVOKE, rule_id=rule["rule_id"])
     assert revoked["removed"] is True
+
+
+@pytest.mark.asyncio
+async def test_approvals_action_handler_poll_returns_pending_request(manager) -> None:
+    handler = ApprovalsActionHandler(manager)
+
+    first = await manager.evaluate(
+        capability_id="run_command",
+        params={"command": "git status --short"},
+        session_id="session-poll",
+        reason="Tool run_command requires approval",
+    )
+    assert first.request is not None
+
+    polled = await handler.invoke(ResourceAction.APPROVALS_POLL)
+    request = polled["request"]
+    assert isinstance(request, dict)
+    assert request["request_id"] == first.request.request_id
+
+
+@pytest.mark.asyncio
+async def test_approvals_action_handler_poll_timeout_returns_null_request(manager) -> None:
+    handler = ApprovalsActionHandler(manager)
+
+    polled = await handler.invoke(ResourceAction.APPROVALS_POLL, timeout_seconds=0.05)
+    assert polled["request"] is None

--- a/tests/unit/test_tool_approval_manager.py
+++ b/tests/unit/test_tool_approval_manager.py
@@ -149,3 +149,42 @@ async def test_revoke_rule_removes_automatic_pass(manager) -> None:
         reason="Tool run_command requires approval",
     )
     assert second.status == ApprovalEvaluationStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_poll_pending_returns_next_request_when_available(manager) -> None:
+    first = await manager.evaluate(
+        capability_id="run_command",
+        params={"command": "git status --short"},
+        session_id="session-poll",
+        reason="Tool run_command requires approval",
+    )
+    assert first.request is not None
+
+    polled = await manager.poll_pending()
+    assert polled is not None
+    assert polled.request_id == first.request.request_id
+
+
+@pytest.mark.asyncio
+async def test_poll_pending_waits_until_request_arrives(manager) -> None:
+    waiter = asyncio.create_task(manager.poll_pending(timeout_seconds=1.0))
+    await asyncio.sleep(0.05)
+
+    first = await manager.evaluate(
+        capability_id="run_command",
+        params={"command": "git status --branch"},
+        session_id="session-poll-wait",
+        reason="Tool run_command requires approval",
+    )
+    assert first.request is not None
+
+    polled = await waiter
+    assert polled is not None
+    assert polled.request_id == first.request.request_id
+
+
+@pytest.mark.asyncio
+async def test_poll_pending_timeout_returns_none(manager) -> None:
+    polled = await manager.poll_pending(timeout_seconds=0.05)
+    assert polled is None

--- a/tests/unit/test_transport_adapters.py
+++ b/tests/unit/test_transport_adapters.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from dare_framework.transport._internal.adapters import StdioClientChannel, WebSocketClientChannel
+from dare_framework.transport._internal.adapters import DirectClientChannel, StdioClientChannel, WebSocketClientChannel
 from dare_framework.transport.types import EnvelopeKind, TransportEnvelope
 
 
@@ -45,3 +45,40 @@ async def test_websocket_requires_explicit_kind() -> None:
 
     with pytest.raises(ValueError, match="kind"):
         await ws.handle_ws_message({"id": "req-1", "payload": "hello"})
+
+
+@pytest.mark.asyncio
+async def test_direct_client_channel_poll_receives_unmatched_agent_messages() -> None:
+    channel = DirectClientChannel()
+
+    async def sender(msg: TransportEnvelope) -> None:
+        _ = msg
+
+    channel.attach_agent_envelope_sender(sender)
+    receiver = channel.agent_envelope_receiver()
+
+    await receiver(
+        TransportEnvelope(
+            id="event-1",
+            kind=EnvelopeKind.MESSAGE,
+            payload={"type": "approval_pending", "request_id": "req-1"},
+        )
+    )
+
+    polled = await channel.poll(timeout=0.2)
+    assert polled is not None
+    assert polled.id == "event-1"
+    assert isinstance(polled.payload, dict)
+    assert polled.payload.get("type") == "approval_pending"
+
+
+@pytest.mark.asyncio
+async def test_direct_client_channel_poll_times_out_when_empty() -> None:
+    channel = DirectClientChannel()
+
+    async def sender(msg: TransportEnvelope) -> None:
+        _ = msg
+
+    channel.attach_agent_envelope_sender(sender)
+    polled = await channel.poll(timeout=0.05)
+    assert polled is None


### PR DESCRIPTION
## Summary
- add first-class approval notifications on the transport stream (approval_pending / approval_resolved)
- add control-plane blocking poll support via approvals:poll and ToolApprovalManager.poll_pending(...)
- add unsolicited event polling to DirectClientChannel so clients can consume approval notifications without losing request/response semantics
- propagate reply_to for transport message responses in the agent loop to make DirectClientChannel.ask(...) work end-to-end
- extend 05/06 CLI with /approvals poll, fix approvals invoke parameter passing, and refresh docs/demo scripts
- update example 07 to demonstrate channel request/response + approval event polling flow

## Why
Current approval flow depended on hook/event side effects and approvals:list polling. It did not provide Codex/Claude-style explicit pending approval events over the channel, and request/response in the channel loop could not reliably resolve via ask() because message replies were missing reply_to.

## Validation
- pytest -q tests/unit/test_tool_approval_manager.py tests/unit/test_tool_approval_action_handler.py tests/unit/test_transport_adapters.py tests/unit/test_five_layer_agent.py tests/unit/test_examples_cli.py tests/unit/test_examples_cli_mcp.py tests/unit/test_base_agent_transport_contract.py -k "approval or poll or transport or examples_cli"
- pytest -q tests/unit/test_transport_channel.py tests/unit/test_interaction_dispatcher.py tests/unit/test_mcp_action_handler.py tests/unit/test_base_agent_transport_contract.py tests/unit/test_tool_approval_manager.py tests/unit/test_tool_approval_action_handler.py tests/unit/test_transport_adapters.py tests/unit/test_examples_cli.py tests/unit/test_examples_cli_mcp.py tests/unit/test_five_layer_agent.py -k "approval or transport or interaction or mcp_action or examples_cli or base_agent_transport_contract"
- python examples/07-tool-approval-memory/main.py
