### PR TITLE
ci: manual-merge-guard to prevent auto ship on main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,3 +46,4 @@ Reference: `docs/agent_rules.md`
 - [ ] Public interfaces/data structures unchanged unless explicitly required
 - [ ] Tests added/updated and evidence attached
 - [ ] Any `skip/only/exclude` usage is explained and reviewed
+- [ ] Merge will be done by approved reviewer (no self-merge auto-ship)

--- a/.github/workflows/manual-merge-guard.yml
+++ b/.github/workflows/manual-merge-guard.yml
@@ -1,0 +1,149 @@
+name: manual-merge-guard
+
+on:
+  pull_request_target:
+    types: [closed]
+  workflow_dispatch:
+
+concurrency:
+  # Preserve every incident run for audit trail.
+  group: manual-merge-guard-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  enforce-manual-approval:
+    name: enforce-manual-approval
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
+    runs-on: ubuntu-latest
+    env:
+      MANUAL_MERGE_GUARD_MODE: ${{ vars.MANUAL_MERGE_GUARD_MODE }}
+      MANUAL_MERGE_GUARD_ALLOW_MERGERS: ${{ vars.MANUAL_MERGE_GUARD_ALLOW_MERGERS }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Classify merged PR event
+        id: classify
+        run: |
+          python scripts/ci/manual_merge_guard.py \
+            --event "$GITHUB_EVENT_PATH" \
+            --repository "$GITHUB_REPOSITORY" \
+            --token "${{ secrets.GITHUB_TOKEN }}" \
+            --allow-mergers "${MANUAL_MERGE_GUARD_ALLOW_MERGERS:-}"
+
+      - name: Write run summary
+        run: |
+          {
+            echo "## Manual Merge Guard Result"
+            echo "- Eligible event: \`${{ steps.classify.outputs.is_eligible_event }}\`"
+            echo "- Compliant: \`${{ steps.classify.outputs.is_compliant }}\`"
+            echo "- Needs rollback: \`${{ steps.classify.outputs.needs_rollback }}\`"
+            echo "- Reason: \`${{ steps.classify.outputs.reason }}\`"
+            echo "- PR number: \`${{ steps.classify.outputs.pr_number }}\`"
+            echo "- Author: \`${{ steps.classify.outputs.author }}\`"
+            echo "- Merger: \`${{ steps.classify.outputs.merger }}\`"
+            echo "- Approved reviewers: \`${{ steps.classify.outputs.approved_reviewers }}\`"
+            echo "- Mode: \`${MANUAL_MERGE_GUARD_MODE:-revert-pr}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create incident issue
+        id: incident
+        if: steps.classify.outputs.needs_rollback == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mode="${MANUAL_MERGE_GUARD_MODE:-revert-pr}"
+          title="Manual-merge-guard incident: PR #${{ steps.classify.outputs.pr_number }}"
+          body=$(cat <<EOF
+          ## Manual Merge Guard Incident
+
+          A non-compliant merge to \`main\` was detected.
+
+          - Repo: \`${GITHUB_REPOSITORY}\`
+          - PR: #${{ steps.classify.outputs.pr_number }}
+          - Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          - Reason: \`${{ steps.classify.outputs.reason }}\`
+          - Author: \`${{ steps.classify.outputs.author }}\`
+          - Merger: \`${{ steps.classify.outputs.merger }}\`
+          - Approved reviewers: \`${{ steps.classify.outputs.approved_reviewers }}\`
+          - Mode: \`${mode}\`
+          EOF
+          )
+          issue_url=$(gh issue create --title "$title" --body "$body")
+          echo "issue_url=$issue_url" >> "$GITHUB_OUTPUT"
+
+      - name: Create rollback branch and PR
+        id: rollback
+        if: steps.classify.outputs.needs_rollback == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_SHA: ${{ steps.classify.outputs.merge_commit_sha }}
+        run: |
+          mode="${MANUAL_MERGE_GUARD_MODE:-revert-pr}"
+          if [ "$mode" != "revert-pr" ]; then
+            echo "rollback_pr_url=" >> "$GITHUB_OUTPUT"
+            echo "Skipping rollback PR because MANUAL_MERGE_GUARD_MODE=${mode}."
+            exit 0
+          fi
+
+          if [ -z "$MERGE_SHA" ]; then
+            echo "rollback_pr_url=" >> "$GITHUB_OUTPUT"
+            echo "Missing merge_commit_sha; cannot create rollback PR."
+            exit 0
+          fi
+
+          git config user.name "manual-merge-guard[bot]"
+          git config user.email "manual-merge-guard[bot]@users.noreply.github.com"
+
+          rollback_branch="auto/manual-merge-guard-revert-${GITHUB_RUN_ID}"
+          git switch --create "$rollback_branch"
+
+          parent_words=$(git rev-list --parents -n 1 "$MERGE_SHA" | wc -w | tr -d ' ')
+          if [ "$parent_words" -ge 3 ]; then
+            git revert -m 1 --no-edit "$MERGE_SHA"
+          else
+            git revert --no-edit "$MERGE_SHA"
+          fi
+
+          git push origin "$rollback_branch"
+          rollback_pr_url=$(gh pr create \
+            --base main \
+            --head "$rollback_branch" \
+            --title "revert: non-compliant merge for PR #${{ steps.classify.outputs.pr_number }}" \
+            --body "Auto-generated rollback PR by \`manual-merge-guard\`.
+
+          - Incident run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          - Reason: \`${{ steps.classify.outputs.reason }}\`
+          - Merge SHA reverted: \`${MERGE_SHA}\`")
+          echo "rollback_pr_url=$rollback_pr_url" >> "$GITHUB_OUTPUT"
+
+      - name: Add remediation links to summary
+        if: steps.classify.outputs.needs_rollback == 'true'
+        run: |
+          {
+            echo ""
+            echo "## Manual Merge Guard Remediation"
+            echo "- Incident issue: \`${{ steps.incident.outputs.issue_url }}\`"
+            echo "- Rollback PR: \`${{ steps.rollback.outputs.rollback_pr_url }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Mark policy violation
+        if: steps.classify.outputs.needs_rollback == 'true'
+        run: |
+          echo "Manual merge policy violation detected and remediation workflow executed."
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,3 +68,17 @@ For GitHub branch protection and merge queue settings, follow `docs/governance/b
 - `MAIN_GUARD_ALLOW_MARKER`: commit marker to bypass incident (default `[main-guard:allow-direct-push]`)
 
 Use bypass only for emergency hotfixes and always attach a postmortem note in follow-up PR/issue.
+
+## Manual Merge Guard (No Auto-Self-Merge Fallback)
+- Workflow: `.github/workflows/manual-merge-guard.yml`
+- Trigger: every merged PR close event on `main` (`pull_request_target: closed`)
+- Policy:
+  - merged PR must have at least one independent `APPROVED` review
+  - self-merge (`author == merged_by`) is treated as non-compliant by default
+  - non-compliant merge triggers incident issue + optional rollback PR
+
+### Repository Variables
+- `MANUAL_MERGE_GUARD_MODE`: `revert-pr` (default) or `alert-only`
+- `MANUAL_MERGE_GUARD_ALLOW_MERGERS`: comma-separated emergency allowlist for mergers
+
+This is a free-tier fallback when GitHub branch protection/rulesets are not available on private repositories.

--- a/docs/governance/branch-protection.md
+++ b/docs/governance/branch-protection.md
@@ -57,6 +57,24 @@ Use `.github/workflows/main-guard.yml` as an automated guard rail:
 
 This fallback does not replace native branch protection, but it gives enforceable detection and remediation when plan limits block branch rules.
 
+## Free-Tier Fallback: Manual Approval Enforcement
+Use `.github/workflows/manual-merge-guard.yml` to enforce a review-based policy after merge:
+
+1. Trigger on merged PR close events targeting `main`.
+2. Mark non-compliant when:
+   - PR is self-merged (`author == merged_by`), or
+   - no independent `APPROVED` review exists.
+3. Open incident issue automatically.
+4. In `MANUAL_MERGE_GUARD_MODE=revert-pr`, auto-create a rollback PR.
+5. Fail the guard run for visible audit signal.
+
+### Variables
+- `MANUAL_MERGE_GUARD_MODE`
+  - `revert-pr`: detect + issue + rollback PR
+  - `alert-only`: detect + issue only
+- `MANUAL_MERGE_GUARD_ALLOW_MERGERS`
+  - Emergency merger allowlist (comma-separated)
+
 ## Verification Steps
 1. Open a small PR.
 2. Confirm `lint` and `build` run automatically.

--- a/docs/guides/Team_Agent_Collab_Playbook.md
+++ b/docs/guides/Team_Agent_Collab_Playbook.md
@@ -70,6 +70,21 @@ pytest -q tests/smoke -m smoke
 - `MAIN_GUARD_ALLOW_ACTORS`: 紧急允许直推的 actor 白名单（逗号分隔）
 - `MAIN_GUARD_ALLOW_MARKER`: 提交信息绕过标记（默认 `[main-guard:allow-direct-push]`）
 
+## 4.1 合并人工审批护栏（manual-merge-guard）
+
+工作流：
+- `/Users/lysander/projects/dare-framework/.github/workflows/manual-merge-guard.yml`
+
+作用：
+1. PR 合入 `main` 后检查是否符合人工审批策略。
+2. 默认把“作者自合并”视为违规（`author == merged_by`）。
+3. 必须存在至少一个独立 `APPROVED` review。
+4. 违规时自动发 incident，必要时自动回滚 PR。
+
+仓库变量：
+- `MANUAL_MERGE_GUARD_MODE`: `revert-pr` 或 `alert-only`
+- `MANUAL_MERGE_GUARD_ALLOW_MERGERS`: 紧急白名单（逗号分隔）
+
 ## 5. 冲突最小化策略（并行开发必做）
 
 1. 小 PR：尽量控制在一个目标、少文件、少行数。

--- a/scripts/ci/manual_merge_guard.py
+++ b/scripts/ci/manual_merge_guard.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Enforce manual review policy for PR merges into main (free-tier fallback)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass(slots=True)
+class ManualMergeDecision:
+    is_eligible_event: bool
+    is_compliant: bool
+    reason: str
+    pr_number: int | None
+    author: str
+    merger: str
+    merge_commit_sha: str
+    approved_reviewers: list[str]
+
+
+def load_event(event_path: Path) -> dict:
+    with event_path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def parse_allow_mergers(raw: str) -> set[str]:
+    return {item.strip() for item in raw.split(",") if item.strip()}
+
+
+def _extract_latest_review_states(reviews: list[dict]) -> dict[str, str]:
+    latest_state: dict[str, str] = {}
+    for review in reviews:
+        user = review.get("user") or {}
+        login = str(user.get("login", "")).strip()
+        state = str(review.get("state", "")).strip().upper()
+        if not login:
+            continue
+        latest_state[login] = state
+    return latest_state
+
+
+def find_approved_reviewers(*, reviews: list[dict], author: str) -> list[str]:
+    latest_states = _extract_latest_review_states(reviews)
+    return sorted(
+        reviewer
+        for reviewer, state in latest_states.items()
+        if state == "APPROVED" and reviewer != author
+    )
+
+
+def evaluate_merged_pr_event(
+    *,
+    event: dict,
+    reviews: list[dict],
+    allow_mergers: set[str],
+) -> ManualMergeDecision:
+    action = str(event.get("action", ""))
+    pr = event.get("pull_request") or {}
+    merged = bool(pr.get("merged"))
+    base_ref = str((pr.get("base") or {}).get("ref", ""))
+
+    pr_number = pr.get("number")
+    if not isinstance(pr_number, int):
+        pr_number = None
+
+    author = str((pr.get("user") or {}).get("login", "")).strip()
+    merger = str((pr.get("merged_by") or {}).get("login", "")).strip()
+    merge_commit_sha = str(pr.get("merge_commit_sha", "")).strip()
+
+    if action != "closed" or not merged or base_ref != "main":
+        return ManualMergeDecision(
+            is_eligible_event=False,
+            is_compliant=True,
+            reason="Ignoring non-merged-main pull_request close event.",
+            pr_number=pr_number,
+            author=author,
+            merger=merger,
+            merge_commit_sha=merge_commit_sha,
+            approved_reviewers=[],
+        )
+
+    if merger and merger in allow_mergers:
+        return ManualMergeDecision(
+            is_eligible_event=True,
+            is_compliant=True,
+            reason=f"Ignoring enforcement for allowlisted merger: {merger}.",
+            pr_number=pr_number,
+            author=author,
+            merger=merger,
+            merge_commit_sha=merge_commit_sha,
+            approved_reviewers=[],
+        )
+
+    approved_reviewers = find_approved_reviewers(reviews=reviews, author=author)
+    has_independent_approval = bool(approved_reviewers)
+    is_self_merge = bool(author and merger and author == merger)
+
+    violations: list[str] = []
+    if is_self_merge:
+        violations.append("self-merge detected")
+    if not has_independent_approval:
+        violations.append("missing independent approval review")
+
+    if violations:
+        return ManualMergeDecision(
+            is_eligible_event=True,
+            is_compliant=False,
+            reason="; ".join(violations),
+            pr_number=pr_number,
+            author=author,
+            merger=merger,
+            merge_commit_sha=merge_commit_sha,
+            approved_reviewers=approved_reviewers,
+        )
+
+    return ManualMergeDecision(
+        is_eligible_event=True,
+        is_compliant=True,
+        reason="Manual merge policy satisfied.",
+        pr_number=pr_number,
+        author=author,
+        merger=merger,
+        merge_commit_sha=merge_commit_sha,
+        approved_reviewers=approved_reviewers,
+    )
+
+
+def fetch_pr_reviews(repository: str, pr_number: int, token: str) -> list[dict] | None:
+    url = f"https://api.github.com/repos/{repository}/pulls/{pr_number}/reviews?per_page=100"
+    request = urllib.request.Request(
+        url=url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "manual-merge-guard",
+        },
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError:
+        return None
+    except urllib.error.URLError:
+        return None
+
+    if isinstance(payload, list):
+        return payload
+    return None
+
+
+def _write_output(name: str, value: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with open(output_path, "a", encoding="utf-8") as fh:
+        fh.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event", required=True, type=Path, help="Path to GitHub event payload JSON.")
+    parser.add_argument("--repository", required=True, help="owner/repo")
+    parser.add_argument("--token", default="", help="GitHub token for PR review lookup.")
+    parser.add_argument(
+        "--allow-mergers",
+        default="",
+        help="Comma-separated merger allowlist for emergency bypass.",
+    )
+    args = parser.parse_args()
+
+    event = load_event(args.event)
+    pr = event.get("pull_request") or {}
+    pr_number = pr.get("number")
+
+    reviews: list[dict] = []
+    lookup_failed = False
+    if isinstance(pr_number, int):
+        fetched = fetch_pr_reviews(args.repository, pr_number, args.token)
+        if fetched is None:
+            lookup_failed = True
+        else:
+            reviews = fetched
+
+    decision = evaluate_merged_pr_event(
+        event=event,
+        reviews=reviews,
+        allow_mergers=parse_allow_mergers(args.allow_mergers),
+    )
+
+    # Fail-open on API lookup failures to avoid accidental rollback on GitHub outage.
+    if decision.is_eligible_event and lookup_failed:
+        decision = ManualMergeDecision(
+            is_eligible_event=True,
+            is_compliant=True,
+            reason="Skipping enforcement because PR review lookup failed.",
+            pr_number=decision.pr_number,
+            author=decision.author,
+            merger=decision.merger,
+            merge_commit_sha=decision.merge_commit_sha,
+            approved_reviewers=[],
+        )
+
+    _write_output("is_eligible_event", "true" if decision.is_eligible_event else "false")
+    _write_output("is_compliant", "true" if decision.is_compliant else "false")
+    _write_output("needs_rollback", "true" if decision.is_eligible_event and not decision.is_compliant else "false")
+    _write_output("reason", decision.reason)
+    _write_output("pr_number", "" if decision.pr_number is None else str(decision.pr_number))
+    _write_output("author", decision.author)
+    _write_output("merger", decision.merger)
+    _write_output("merge_commit_sha", decision.merge_commit_sha)
+    _write_output("approved_reviewers", ",".join(decision.approved_reviewers))
+
+    print(json.dumps(asdict(decision), ensure_ascii=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_manual_merge_guard.py
+++ b/tests/unit/test_manual_merge_guard.py
@@ -1,0 +1,74 @@
+from scripts.ci.manual_merge_guard import evaluate_merged_pr_event
+
+
+def _event(
+    *,
+    merged: bool = True,
+    base_ref: str = "main",
+    author: str = "alice",
+    merger: str = "bob",
+    pr_number: int = 71,
+    merge_sha: str = "a" * 40,
+) -> dict:
+    return {
+        "action": "closed",
+        "pull_request": {
+            "number": pr_number,
+            "merged": merged,
+            "base": {"ref": base_ref},
+            "user": {"login": author},
+            "merged_by": {"login": merger},
+            "merge_commit_sha": merge_sha,
+        },
+    }
+
+
+def test_non_main_close_event_is_ignored() -> None:
+    decision = evaluate_merged_pr_event(
+        event=_event(base_ref="feature/x"),
+        reviews=[],
+        allow_mergers=set(),
+    )
+    assert decision.is_eligible_event is False
+    assert decision.is_compliant is True
+
+
+def test_self_merge_is_non_compliant_even_with_approval() -> None:
+    decision = evaluate_merged_pr_event(
+        event=_event(author="alice", merger="alice"),
+        reviews=[{"user": {"login": "bob"}, "state": "APPROVED"}],
+        allow_mergers=set(),
+    )
+    assert decision.is_eligible_event is True
+    assert decision.is_compliant is False
+    assert "self-merge" in decision.reason
+
+
+def test_missing_independent_approval_is_non_compliant() -> None:
+    decision = evaluate_merged_pr_event(
+        event=_event(author="alice", merger="bob"),
+        reviews=[],
+        allow_mergers=set(),
+    )
+    assert decision.is_compliant is False
+    assert "approval" in decision.reason
+
+
+def test_independent_approval_allows_merge() -> None:
+    decision = evaluate_merged_pr_event(
+        event=_event(author="alice", merger="bob"),
+        reviews=[{"user": {"login": "charlie"}, "state": "APPROVED"}],
+        allow_mergers=set(),
+    )
+    assert decision.is_compliant is True
+    assert decision.approved_reviewers == ["charlie"]
+
+
+def test_allowlisted_merger_can_bypass_gate() -> None:
+    decision = evaluate_merged_pr_event(
+        event=_event(author="alice", merger="alice"),
+        reviews=[],
+        allow_mergers={"alice"},
+    )
+    assert decision.is_compliant is True
+    assert "allowlisted merger" in decision.reason


### PR DESCRIPTION
## Summary
- add `manual-merge-guard` workflow to enforce manual approval policy on merged PRs to `main`
- classify non-compliant merges with `scripts/ci/manual_merge_guard.py`
- add unit tests for decision logic (`tests/unit/test_manual_merge_guard.py`)
- update governance docs + PR template to require human approval and no self-merge auto-ship

## Why
On current plan, private repo branch protection/rulesets are unavailable (403), so we need a free-tier guardrail to stop "PR opened then auto-shipped" behavior.

## Policy enforced by fallback
- merged PR on `main` must have independent `APPROVED` review
- self-merge (`author == merged_by`) is non-compliant by default
- non-compliance triggers incident issue and (mode dependent) rollback PR

## Rollout
- repository variable set: `MANUAL_MERGE_GUARD_MODE=alert-only` (safe rollout)
- after 3-5 clean days, can switch to `revert-pr`

## Verification
- `pytest -q tests/unit/test_manual_merge_guard.py` => 5 passed
- `ruff check scripts/ci/manual_merge_guard.py tests/unit/test_manual_merge_guard.py` => clean
- `python -m compileall -q scripts/ci/manual_merge_guard.py tests/unit/test_manual_merge_guard.py` => success
