### PR TITLE
feat(transport): finalize ADR v2 event protocol and approval flow

### DIFF
--- a/dare_framework/agent/base_agent.py
+++ b/dare_framework/agent/base_agent.py
@@ -15,7 +15,12 @@ from dare_framework.agent.kernel import IAgent
 from dare_framework.agent.status import AgentStatus
 from dare_framework.plan.types import RunResult, Task
 from dare_framework.transport.interaction.payloads import build_error_payload, build_success_payload
-from dare_framework.transport.types import EnvelopeKind, TransportEnvelope, new_envelope_id
+from dare_framework.transport.types import (
+    EnvelopeKind,
+    TransportEnvelope,
+    TransportEventType,
+    new_envelope_id,
+)
 
 if TYPE_CHECKING:
     from dare_framework.agent.builder import DareAgentBuilder, ReactAgentBuilder, SimpleChatAgentBuilder
@@ -274,6 +279,7 @@ class BaseAgent(IAgent, IAgentOrchestration, ABC):
         envelope = TransportEnvelope(
             id=new_envelope_id(),
             reply_to=reply_to,
+            event_type=TransportEventType.RESULT.value,
             payload={
                 **build_success_payload(
                     kind="message",
@@ -378,6 +384,7 @@ async def _send_transport_error(
                 id=new_envelope_id(),
                 kind=EnvelopeKind.MESSAGE,
                 reply_to=envelope_id,
+                event_type=TransportEventType.ERROR.value,
                 payload=build_error_payload(
                     kind="message",
                     target=target,

--- a/dare_framework/agent/dare_agent.py
+++ b/dare_framework/agent/dare_agent.py
@@ -56,7 +56,7 @@ from dare_framework.transport.interaction.payloads import (
     build_approval_pending_payload,
     build_approval_resolved_payload,
 )
-from dare_framework.transport.types import TransportEnvelope, new_envelope_id
+from dare_framework.transport.types import TransportEnvelope, TransportEventType, new_envelope_id
 
 
 @dataclass
@@ -1501,7 +1501,10 @@ class DareAgent(BaseAgent):
             tool_name=tool_name,
             tool_call_id=tool_call_id,
         )
-        await self._send_transport_payload(payload)
+        await self._send_transport_payload(
+            payload,
+            event_type=TransportEventType.APPROVAL_PENDING.value,
+        )
 
     async def _emit_approval_resolved_message(
         self,
@@ -1519,14 +1522,23 @@ class DareAgent(BaseAgent):
             tool_name=tool_name,
             tool_call_id=tool_call_id,
         )
-        await self._send_transport_payload(payload)
+        await self._send_transport_payload(
+            payload,
+            event_type=TransportEventType.APPROVAL_RESOLVED.value,
+        )
 
-    async def _send_transport_payload(self, payload: dict[str, Any]) -> None:
+    async def _send_transport_payload(
+        self,
+        payload: dict[str, Any],
+        *,
+        event_type: str | None = None,
+    ) -> None:
         channel = self._active_transport
         if channel is None:
             return
         envelope = TransportEnvelope(
             id=new_envelope_id(),
+            event_type=event_type,
             payload=payload,
         )
         try:

--- a/dare_framework/hook/_internal/agent_event_transport_hook.py
+++ b/dare_framework/hook/_internal/agent_event_transport_hook.py
@@ -9,7 +9,7 @@ from dare_framework.hook.kernel import IHook
 from dare_framework.hook.types import HookPhase
 from dare_framework.infra.component import ComponentType
 from dare_framework.transport.kernel import AgentChannel
-from dare_framework.transport.types import TransportEnvelope, new_envelope_id
+from dare_framework.transport.types import TransportEnvelope, TransportEventType, new_envelope_id
 
 _logger = logging.getLogger("dare.hook")
 
@@ -35,8 +35,8 @@ class AgentEventTransportHook(IHook):
             payload = {}
         envelope = TransportEnvelope(
             id=new_envelope_id(),
+            event_type=TransportEventType.HOOK.value,
             payload={
-                "type": "hook",
                 "phase": phase.value,
                 "payload": payload,
             },

--- a/dare_framework/tool/_internal/control/approval_manager.py
+++ b/dare_framework/tool/_internal/control/approval_manager.py
@@ -217,8 +217,10 @@ class ToolApprovalManager:
         self._pending_by_id: dict[str, _PendingApproval] = {}
         self._pending_by_fingerprint: dict[str, _PendingApproval] = {}
         self._resolved_by_id: dict[str, ApprovalDecision] = {}
-        self._pending_available = asyncio.Event()
         self._lock = asyncio.Lock()
+        # Condition-based wakeups avoid tight loops when polling with a session filter
+        # while unrelated pending requests exist.
+        self._pending_state_changed = asyncio.Condition(self._lock)
 
     @classmethod
     def from_paths(cls, *, workspace_dir: str | Path, user_dir: str | Path) -> ToolApprovalManager:
@@ -231,31 +233,36 @@ class ToolApprovalManager:
         pending.sort(key=lambda item: (item.created_at, item.request_id))
         return pending
 
-    async def poll_pending(self, *, timeout_seconds: float | None = None) -> PendingApprovalRequest | None:
-        """Return the oldest pending approval request, optionally waiting for one."""
+    async def poll_pending(
+        self,
+        *,
+        timeout_seconds: float | None = None,
+        session_id: str | None = None,
+    ) -> PendingApprovalRequest | None:
+        """Return the oldest pending approval request, optionally filtered by session."""
         if timeout_seconds is not None and timeout_seconds < 0:
             raise ValueError("timeout_seconds must be >= 0")
 
         loop = asyncio.get_running_loop()
         deadline = None if timeout_seconds is None else loop.time() + timeout_seconds
-        while True:
-            async with self._lock:
-                request = self._oldest_pending_locked()
+
+        async with self._pending_state_changed:
+            while True:
+                request = self._oldest_pending_locked(session_id=session_id)
                 if request is not None:
                     return request
-                wait_event = self._pending_available
 
-            if deadline is None:
-                await wait_event.wait()
-                continue
+                if deadline is None:
+                    await self._pending_state_changed.wait()
+                    continue
 
-            remaining = deadline - loop.time()
-            if remaining <= 0:
-                return None
-            try:
-                await asyncio.wait_for(wait_event.wait(), timeout=remaining)
-            except asyncio.TimeoutError:
-                return None
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    return None
+                try:
+                    await asyncio.wait_for(self._pending_state_changed.wait(), timeout=remaining)
+                except asyncio.TimeoutError:
+                    return None
 
     def list_rules(self) -> list[ApprovalRule]:
         combined = [
@@ -278,7 +285,8 @@ class ToolApprovalManager:
         command = _extract_command(params)
         fingerprint = _request_fingerprint(capability_id, params_hash)
 
-        async with self._lock:
+        # Use the condition lock consistently for pending-state mutations.
+        async with self._pending_state_changed:
             matched_rule = self._find_matching_rule(
                 capability_id=capability_id,
                 params_hash=params_hash,
@@ -315,7 +323,7 @@ class ToolApprovalManager:
                 existing = _PendingApproval(request=request, fingerprint=fingerprint)
                 self._pending_by_fingerprint[fingerprint] = existing
                 self._pending_by_id[request.request_id] = existing
-                self._pending_available.set()
+                self._pending_state_changed.notify_all()
 
             return ApprovalEvaluation(
                 status=ApprovalEvaluationStatus.PENDING,
@@ -329,7 +337,9 @@ class ToolApprovalManager:
         *,
         timeout_seconds: float | None = None,
     ) -> ApprovalDecision:
-        async with self._lock:
+        # Keep all pending/resolution map access on the same condition-backed lock
+        # so concurrency audits only need to reason about one synchronization surface.
+        async with self._pending_state_changed:
             resolved = self._resolved_by_id.pop(request_id, None)
             if resolved is not None:
                 return resolved
@@ -345,7 +355,7 @@ class ToolApprovalManager:
 
         if pending.resolution is None:
             raise RuntimeError(f"Approval request resolved without decision: {request_id}")
-        async with self._lock:
+        async with self._pending_state_changed:
             self._resolved_by_id.pop(request_id, None)
         return pending.resolution
 
@@ -382,7 +392,7 @@ class ToolApprovalManager:
         )
 
     async def revoke(self, rule_id: str) -> bool:
-        async with self._lock:
+        async with self._pending_state_changed:
             removed = self._remove_rule(rule_id)
             if removed:
                 self._persist_rules_for_scope(removed.scope)
@@ -397,7 +407,8 @@ class ToolApprovalManager:
         matcher: ApprovalMatcherKind,
         matcher_value: str | None,
     ) -> ApprovalRule | None:
-        async with self._lock:
+        # Keep pending-state transitions on the condition lock to avoid mixed styles.
+        async with self._pending_state_changed:
             pending = self._pending_by_id.get(request_id)
             if pending is None:
                 raise KeyError(f"Unknown approval request: {request_id}")
@@ -419,8 +430,7 @@ class ToolApprovalManager:
             self._resolved_by_id[request_id] = decision
             self._pending_by_id.pop(request_id, None)
             self._pending_by_fingerprint.pop(pending.fingerprint, None)
-            if not self._pending_by_id:
-                self._pending_available.clear()
+            self._pending_state_changed.notify_all()
             return rule
 
     def _append_rule(self, rule: ApprovalRule) -> None:
@@ -509,11 +519,16 @@ class ToolApprovalManager:
                 return rule
         return None
 
-    def _oldest_pending_locked(self) -> PendingApprovalRequest | None:
+    def _oldest_pending_locked(self, *, session_id: str | None = None) -> PendingApprovalRequest | None:
         if not self._pending_by_id:
             return None
+        candidates = list(self._pending_by_id.values())
+        if session_id is not None:
+            candidates = [item for item in candidates if item.request.session_id == session_id]
+            if not candidates:
+                return None
         oldest = min(
-            self._pending_by_id.values(),
+            candidates,
             key=lambda item: (item.request.created_at, item.request.request_id),
         )
         return oldest.request

--- a/dare_framework/tool/action_handler.py
+++ b/dare_framework/tool/action_handler.py
@@ -77,7 +77,11 @@ class ApprovalsActionHandler(IActionHandler):
 
         if action == ResourceAction.APPROVALS_POLL:
             timeout_seconds = _parse_timeout_seconds(params)
-            request = await self._approval_manager.poll_pending(timeout_seconds=timeout_seconds)
+            session_id = _optional_session_id(params.get("session_id"))
+            request = await self._approval_manager.poll_pending(
+                timeout_seconds=timeout_seconds,
+                session_id=session_id,
+            )
             return {"request": _pending_to_dict(request) if request is not None else None}
 
         if action == ResourceAction.APPROVALS_GRANT:
@@ -174,6 +178,13 @@ def _parse_matcher(raw: Any, *, default: ApprovalMatcherKind) -> ApprovalMatcher
 
 
 def _optional_matcher_value(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    return text or None
+
+
+def _optional_session_id(raw: Any) -> str | None:
     if raw is None:
         return None
     text = str(raw).strip()

--- a/dare_framework/transport/__init__.py
+++ b/dare_framework/transport/__init__.py
@@ -1,9 +1,11 @@
 """transport domain facade."""
 
-from dare_framework.transport.interfaces import AgentChannel, ClientChannel
+from dare_framework.transport.interfaces import AgentChannel, ClientChannel, PollableClientChannel
 from dare_framework.transport.types import (
     EnvelopeKind,
+    TransportEventType,
     TransportEnvelope,
+    normalize_transport_event_type,
     new_envelope_id,
     Receiver,
     Sender,
@@ -23,8 +25,11 @@ from dare_framework.transport._internal import (
 __all__ = [
     "AgentChannel",
     "ClientChannel",
+    "PollableClientChannel",
     "EnvelopeKind",
+    "TransportEventType",
     "TransportEnvelope",
+    "normalize_transport_event_type",
     "new_envelope_id",
     "Receiver",
     "Sender",

--- a/dare_framework/transport/_internal/adapters.py
+++ b/dare_framework/transport/_internal/adapters.py
@@ -7,8 +7,16 @@ import json
 from typing import Any, Callable
 
 from dare_framework.transport.interaction.controls import AgentControl
-from dare_framework.transport.kernel import ClientChannel
-from dare_framework.transport.types import EnvelopeKind, Receiver, Sender, TransportEnvelope, new_envelope_id
+from dare_framework.transport.kernel import ClientChannel, PollableClientChannel
+from dare_framework.transport.types import (
+    EnvelopeKind,
+    normalize_transport_event_type,
+    Receiver,
+    Sender,
+    TransportEnvelope,
+    TransportEventType,
+    new_envelope_id,
+)
 
 
 class StdioClientChannel(ClientChannel):
@@ -30,10 +38,10 @@ class StdioClientChannel(ClientChannel):
 
     def agent_envelope_receiver(self) -> Receiver:
         async def recv(msg: TransportEnvelope) -> None:
+            event_type = _resolve_transport_event_type(msg)
             payload = msg.payload
             if isinstance(payload, dict):
-                payload_type = payload.get("type")
-                if payload_type == "result":
+                if event_type == TransportEventType.RESULT.value:
                     kind = payload.get("kind")
                     resp = payload.get("resp")
                     if kind == "message":
@@ -43,9 +51,9 @@ class StdioClientChannel(ClientChannel):
                             output = payload.get("output")
                     else:
                         output = resp if resp is not None else payload
-                elif payload_type == "error":
+                elif event_type == TransportEventType.ERROR.value:
                     output = payload.get("reason") or payload.get("error")
-                elif payload_type == "approval_pending":
+                elif event_type == TransportEventType.APPROVAL_PENDING.value:
                     resp = payload.get("resp")
                     request_id = None
                     if isinstance(resp, dict):
@@ -53,7 +61,7 @@ class StdioClientChannel(ClientChannel):
                         if isinstance(request, dict):
                             request_id = request.get("request_id")
                     output = f"approval pending: request_id={request_id or '?'}"
-                elif payload_type == "approval_resolved":
+                elif event_type == TransportEventType.APPROVAL_RESOLVED.value:
                     resp = payload.get("resp")
                     request_id = None
                     decision = None
@@ -61,7 +69,7 @@ class StdioClientChannel(ClientChannel):
                         request_id = resp.get("request_id")
                         decision = resp.get("decision")
                     output = f"approval resolved: request_id={request_id or '?'} decision={decision or '?'}"
-                elif payload_type == "hook":
+                elif event_type == TransportEventType.HOOK.value:
                     output = payload.get("event")
                 else:
                     output = payload
@@ -142,7 +150,7 @@ class WebSocketClientChannel(ClientChannel):
         await self._sender(envelope)
 
 
-class DirectClientChannel(ClientChannel):
+class DirectClientChannel(PollableClientChannel):
     """Direct in-process adapter for request/response patterns."""
 
     def __init__(self) -> None:
@@ -172,6 +180,7 @@ class DirectClientChannel(ClientChannel):
                 id=new_envelope_id(),
                 reply_to=req.reply_to,
                 kind=req.kind,
+                event_type=req.event_type,
                 payload=req.payload,
                 meta=req.meta,
                 stream_id=req.stream_id,
@@ -203,6 +212,7 @@ def _default_serialize(msg: TransportEnvelope) -> str:
         "id": msg.id,
         "reply_to": msg.reply_to,
         "kind": msg.kind,
+        "event_type": msg.event_type,
         "payload": msg.payload,
         "meta": msg.meta,
         "stream_id": msg.stream_id,
@@ -226,11 +236,19 @@ def _default_deserialize(raw: Any) -> TransportEnvelope:
         id=str(data.get("id") or new_envelope_id()),
         reply_to=data.get("reply_to"),
         kind=data.get("kind"),
+        event_type=data.get("event_type"),
         payload=data.get("payload"),
         meta=data.get("meta") or {},
         stream_id=data.get("stream_id"),
         seq=data.get("seq"),
     )
+
+
+def _resolve_transport_event_type(msg: TransportEnvelope) -> str | None:
+    """Resolve event_type for receiver routing."""
+    if isinstance(msg.event_type, str):
+        return normalize_transport_event_type(msg.event_type)
+    return None
 
 
 __all__ = ["StdioClientChannel", "WebSocketClientChannel", "DirectClientChannel"]

--- a/dare_framework/transport/_internal/default_channel.py
+++ b/dare_framework/transport/_internal/default_channel.py
@@ -16,6 +16,7 @@ from dare_framework.transport.types import (
     Receiver,
     Sender,
     TransportEnvelope,
+    TransportEventType,
     new_envelope_id,
 )
 
@@ -258,6 +259,7 @@ class DefaultAgentChannel(AgentChannel):
                 id=new_envelope_id(),
                 reply_to=reply_to,
                 kind=EnvelopeKind.MESSAGE,
+                event_type=TransportEventType.RESULT.value,
                 payload=build_success_payload(
                     kind=kind,
                     target=target,
@@ -280,6 +282,7 @@ class DefaultAgentChannel(AgentChannel):
                 id=new_envelope_id(),
                 reply_to=reply_to,
                 kind=EnvelopeKind.MESSAGE,
+                event_type=TransportEventType.ERROR.value,
                 payload=build_error_payload(
                     kind=kind,
                     target=target,

--- a/dare_framework/transport/interaction/payloads.py
+++ b/dare_framework/transport/interaction/payloads.py
@@ -8,7 +8,6 @@ from typing import Any
 def build_success_payload(*, kind: str, target: str, resp: Any) -> dict[str, Any]:
     """Build a unified success payload for action/control/message paths."""
     return {
-        "type": "result",
         "kind": kind,
         "target": target,
         "ok": True,
@@ -20,7 +19,6 @@ def build_error_payload(*, kind: str, target: str, code: str, reason: str) -> di
     """Build a unified error payload with deterministic error fields."""
     detail = {"code": code, "reason": reason}
     return {
-        "type": "error",
         "kind": kind,
         "target": target,
         "ok": False,
@@ -40,7 +38,6 @@ def build_approval_pending_payload(
 ) -> dict[str, Any]:
     """Build a transport payload for a pending tool approval request."""
     return {
-        "type": "approval_pending",
         "kind": "approval",
         "target": capability_id,
         "ok": True,
@@ -63,7 +60,6 @@ def build_approval_resolved_payload(
 ) -> dict[str, Any]:
     """Build a transport payload for a resolved tool approval request."""
     return {
-        "type": "approval_resolved",
         "kind": "approval",
         "target": capability_id,
         "ok": True,

--- a/dare_framework/transport/interfaces.py
+++ b/dare_framework/transport/interfaces.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from dare_framework.transport.kernel import AgentChannel, ClientChannel
+from dare_framework.transport.kernel import AgentChannel, ClientChannel, PollableClientChannel
 
-__all__ = ["AgentChannel", "ClientChannel"]
+__all__ = ["AgentChannel", "ClientChannel", "PollableClientChannel"]

--- a/dare_framework/transport/kernel.py
+++ b/dare_framework/transport/kernel.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from dare_framework.transport.types import (
     Receiver,
@@ -23,6 +23,14 @@ class ClientChannel(Protocol):
 
     def agent_envelope_receiver(self) -> Receiver:
         """Return the receiver used to deliver envelopes from the agent outbox."""
+
+
+@runtime_checkable
+class PollableClientChannel(ClientChannel, Protocol):
+    """Extension for client channels that support polling unsolicited events."""
+
+    async def poll(self, timeout: float | None = None) -> TransportEnvelope | None:
+        """Poll unsolicited envelopes emitted by the agent channel."""
 
 
 class AgentChannel(Protocol):
@@ -75,4 +83,4 @@ class AgentChannel(Protocol):
         )
 
 
-__all__ = ["AgentChannel", "ClientChannel"]
+__all__ = ["AgentChannel", "ClientChannel", "PollableClientChannel"]

--- a/dare_framework/transport/types.py
+++ b/dare_framework/transport/types.py
@@ -16,6 +16,33 @@ class EnvelopeKind(StrEnum):
     CONTROL = "control"
 
 
+class TransportEventType(StrEnum):
+    """Canonical event categories carried by message envelopes."""
+
+    RESULT = "result"
+    ERROR = "error"
+    HOOK = "hook"
+    APPROVAL_PENDING = "approval.pending"
+    APPROVAL_RESOLVED = "approval.resolved"
+
+
+_LEGACY_PAYLOAD_EVENT_TYPE_MAP: dict[str, str] = {
+    # Only legacy aliases that differ from canonical event_type values.
+    "approval_pending": TransportEventType.APPROVAL_PENDING.value,
+    "approval_resolved": TransportEventType.APPROVAL_RESOLVED.value,
+}
+
+
+def normalize_transport_event_type(raw: str | None) -> str | None:
+    """Normalize legacy/new event_type strings into canonical values."""
+    if raw is None:
+        return None
+    normalized = raw.strip()
+    if not normalized:
+        return None
+    return _LEGACY_PAYLOAD_EVENT_TYPE_MAP.get(normalized, normalized)
+
+
 @dataclass(frozen=True)
 class TransportEnvelope:
     """Transport envelope for agent/client messages."""
@@ -23,6 +50,7 @@ class TransportEnvelope:
     id: str
     reply_to: str | None = None
     kind: EnvelopeKind = EnvelopeKind.MESSAGE
+    event_type: str | None = None
     payload: Any = None
     meta: dict[str, Any] = field(default_factory=dict)
     stream_id: str | None = None
@@ -35,9 +63,22 @@ class TransportEnvelope:
                 object.__setattr__(self, "kind", EnvelopeKind(kind))
             except ValueError as exc:
                 raise ValueError(f"invalid envelope kind: {kind!r}") from exc
-            return
+            kind = self.kind
         if not isinstance(kind, EnvelopeKind):
             raise TypeError(f"invalid envelope kind type: {type(kind).__name__}")
+
+        event_type = self.event_type
+        if isinstance(event_type, TransportEventType):
+            object.__setattr__(self, "event_type", event_type.value)
+            return
+        if event_type is None:
+            return
+        if not isinstance(event_type, str):
+            raise TypeError(f"invalid event_type type: {type(event_type).__name__}")
+        normalized = normalize_transport_event_type(event_type)
+        if normalized is None:
+            raise ValueError("event_type must not be empty")
+        object.__setattr__(self, "event_type", normalized)
 
 
 def new_envelope_id() -> str:
@@ -51,6 +92,8 @@ Receiver = Callable[[TransportEnvelope], Awaitable[None]]
 
 __all__ = [
     "EnvelopeKind",
+    "TransportEventType",
+    "normalize_transport_event_type",
     "TransportEnvelope",
     "new_envelope_id",
     "Sender",

--- a/docs/guides/Tool_Approval_Memory.md
+++ b/docs/guides/Tool_Approval_Memory.md
@@ -115,6 +115,7 @@
 可选参数：
 
 - `timeout_seconds` 或 `timeout_ms`
+- `session_id`（仅返回该 session 的最早 pending）
 
 输出：
 
@@ -134,8 +135,10 @@
 
 当 `requires_approval=true` 的工具调用进入 pending 时，runtime 会通过 transport 主动发出：
 
-- `type="approval_pending"`：包含 pending request 详情
-- `type="approval_resolved"`：包含 request_id 与最终 decision（allow/deny）
+- `event_type="approval.pending"`：包含 pending request 详情
+- `event_type="approval.resolved"`：包含 request_id 与最终 decision（allow/deny）
+
+协议说明：客户端应仅使用 `event_type` 做分流；`payload.type` 已移除。
 
 这允许客户端实现 Codex/Claude Code 风格的“消息流里出现审批卡片”，同时再用 `approvals:grant|deny` 完成决策。
 
@@ -155,7 +158,7 @@
 `examples/05-dare-coding-agent-enhanced/cli.py` 与 `examples/06-dare-coding-agent-mcp/cli.py` 都支持：
 
 - `/approvals list`
-- `/approvals poll [timeout_ms=30000]`
+- `/approvals poll [timeout_ms=30000] [session_id=...]`
 - `/approvals grant <request_id> [scope=workspace] [matcher=exact_params] [matcher_value=...]`
 - `/approvals deny <request_id> [scope=once] [matcher=exact_params] [matcher_value=...]`
 - `/approvals revoke <rule_id>`

--- a/examples/05-dare-coding-agent-enhanced/README.md
+++ b/examples/05-dare-coding-agent-enhanced/README.md
@@ -29,7 +29,7 @@ python main.py
 - `/reject`：取消当前计划
 - `/status`：查看状态
 - `/approvals list`：查看待审批请求与当前审批规则
-- `/approvals poll [timeout_ms=30000]`：阻塞等待下一个待审批请求（无请求则超时返回）
+- `/approvals poll [timeout_ms=30000] [session_id=...]`：阻塞等待下一个待审批请求（可按 session 过滤）
 - `/approvals grant <request_id> [scope=workspace] [matcher=exact_params] [matcher_value=...]`：批准请求并可写入规则
 - `/approvals deny <request_id> [scope=once] [matcher=exact_params] [matcher_value=...]`：拒绝请求并可写入规则
 - `/approvals revoke <rule_id>`：撤销审批规则

--- a/examples/05-dare-coding-agent-enhanced/cli.py
+++ b/examples/05-dare-coding-agent-enhanced/cli.py
@@ -28,8 +28,8 @@ from dare_framework.event.types import Event, RuntimeSnapshot
 from dare_framework.knowledge import create_knowledge
 from dare_framework.model import OpenRouterModelAdapter
 from dare_framework.plan import DefaultPlanner, DefaultRemediator, Task
-from dare_framework.tool.action_handler import ApprovalsActionHandler
 from dare_framework.tool._internal.tools import ReadFileTool, RunCommandTool, SearchCodeTool, WriteFileTool
+from dare_framework.transport import AgentChannel, DirectClientChannel, EnvelopeKind, TransportEnvelope, new_envelope_id
 from dare_framework.transport.interaction.resource_action import ResourceAction
 
 from validators.file_validator import FileExistsValidator
@@ -269,6 +269,7 @@ def _create_builder(
     display: CLIDisplay,
     *,
     config: Config | None = None,
+    agent_channel: AgentChannel | None = None,
 ) -> DareAgentBuilder:
     """创建 DareAgentBuilder；MCP 与 initial_skill_path 由 builder.build() 内部从 config 读取。"""
     model = OpenRouterModelAdapter(
@@ -303,6 +304,8 @@ def _create_builder(
         .with_remediator(DefaultRemediator(model, verbose=False))
         .with_event_log(event_log)
     )
+    if agent_channel is not None:
+        builder = builder.with_agent_channel(agent_channel)
     return builder
 
 
@@ -433,17 +436,43 @@ async def _handle_mcp_command(
 
 def _approvals_usage(display: CLIDisplay) -> None:
     display.info("/approvals list")
-    display.info("/approvals poll [timeout_ms=30000]")
+    display.info("/approvals poll [timeout_ms=30000] [session_id=...]")
     display.info("/approvals grant <request_id> [scope=workspace] [matcher=exact_params] [matcher_value=...]")
     display.info("/approvals deny <request_id> [scope=once] [matcher=exact_params] [matcher_value=...]")
     display.info("/approvals revoke <rule_id>")
 
 
-def _resolve_approvals_handler(agent: Any) -> ApprovalsActionHandler | None:
-    approval_manager = getattr(agent, "_approval_manager", None)
-    if approval_manager is None:
-        return None
-    return ApprovalsActionHandler(approval_manager)
+async def _invoke_approval_action(
+    approval_client: DirectClientChannel,
+    action: ResourceAction,
+    *,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    request = TransportEnvelope(
+        id=new_envelope_id(),
+        kind=EnvelopeKind.ACTION,
+        payload=action.value,
+        meta=dict(params or {}),
+    )
+    response = await approval_client.ask(request, timeout=30.0)
+    payload = response.payload
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"unexpected action response payload: {payload!r}")
+
+    event_type = response.event_type
+    if not isinstance(event_type, str) or not event_type:
+        raise RuntimeError("invalid action response: missing event_type")
+    if event_type == "error":
+        raise RuntimeError(str(payload.get("reason") or payload.get("error") or "action failed"))
+
+    resp = payload.get("resp")
+    if not isinstance(resp, dict):
+        raise RuntimeError(f"unexpected action response shape: {payload!r}")
+
+    result = resp.get("result")
+    if not isinstance(result, dict):
+        raise RuntimeError(f"unexpected action result shape: {payload!r}")
+    return result
 
 
 def _parse_key_value_args(tokens: list[str]) -> tuple[list[str], dict[str, str]]:
@@ -473,15 +502,23 @@ def _build_approval_action_params(
     return params
 
 
+def _build_approval_poll_params(trailing_args: list[str]) -> dict[str, Any]:
+    _positional, options = _parse_key_value_args(trailing_args)
+    params: dict[str, Any] = {}
+    for key in ("timeout_ms", "timeout_seconds", "session_id"):
+        if key in options and options[key]:
+            params[key] = options[key]
+    return params
+
+
 async def _handle_approvals_command(
     args: list[str],
     *,
-    agent: Any,
+    approval_client: DirectClientChannel | None,
     display: CLIDisplay,
 ) -> None:
-    handler = _resolve_approvals_handler(agent)
-    if handler is None:
-        display.warn("approval manager unavailable on current agent")
+    if approval_client is None:
+        display.warn("approval transport unavailable")
         return
     if not args:
         _approvals_usage(display)
@@ -490,7 +527,7 @@ async def _handle_approvals_command(
     subcommand = args[0].lower()
     try:
         if subcommand == "list":
-            result = await handler.invoke(ResourceAction.APPROVALS_LIST)
+            result = await _invoke_approval_action(approval_client, ResourceAction.APPROVALS_LIST)
             pending = result.get("pending", [])
             rules = result.get("rules", [])
             display.info(f"pending={len(pending)} rules={len(rules)}")
@@ -498,12 +535,12 @@ async def _handle_approvals_command(
             return
 
         if subcommand == "poll":
-            _positional, options = _parse_key_value_args(args[1:])
-            params: dict[str, Any] = {}
-            for key in ("timeout_ms", "timeout_seconds"):
-                if key in options and options[key]:
-                    params[key] = options[key]
-            result = await handler.invoke(ResourceAction.APPROVALS_POLL, **params)
+            params = _build_approval_poll_params(args[1:])
+            result = await _invoke_approval_action(
+                approval_client,
+                ResourceAction.APPROVALS_POLL,
+                params=params,
+            )
             request = result.get("request")
             if isinstance(request, dict):
                 display.info(f"pending request: {request.get('request_id', '?')}")
@@ -524,7 +561,7 @@ async def _handle_approvals_command(
                 else ResourceAction.APPROVALS_DENY
             )
             params = _build_approval_action_params(request_id=request_id, trailing_args=args[2:])
-            result = await handler.invoke(action, **params)
+            result = await _invoke_approval_action(approval_client, action, params=params)
             display.ok(f"{subcommand} applied: {request_id}")
             print(json.dumps(result, ensure_ascii=False, indent=2), flush=True)
             return
@@ -535,9 +572,10 @@ async def _handle_approvals_command(
                 _approvals_usage(display)
                 return
             rule_id = args[1]
-            result = await handler.invoke(
+            result = await _invoke_approval_action(
+                approval_client,
                 ResourceAction.APPROVALS_REVOKE,
-                rule_id=rule_id,
+                params={"rule_id": rule_id},
             )
             if result.get("removed"):
                 display.ok(f"revoked rule: {rule_id}")
@@ -604,6 +642,7 @@ async def run_cli_loop(
     model: OpenRouterModelAdapter,
     display: CLIDisplay,
     mcp_state: MCPRuntimeState | None = None,
+    approval_client: DirectClientChannel | None = None,
     state: CLISessionState | None = None,
     background_execute: bool = False,
 ) -> tuple[CLISessionState, bool]:
@@ -642,7 +681,7 @@ async def run_cli_loop(
             if cmd.type == CommandType.APPROVALS:
                 await _handle_approvals_command(
                     cmd.args,
-                    agent=agent,
+                    approval_client=approval_client,
                     display=display,
                 )
                 continue
@@ -763,6 +802,8 @@ async def main(argv: list[str] | None = None) -> None:
     if config.mcp_paths:
         display.info("MCP config found. Start local_mcp_server.py in another terminal if using local_math.")
 
+    approval_client = DirectClientChannel()
+    approval_channel = AgentChannel.build(approval_client)
     builder = _create_builder(
         workspace,
         model_name,
@@ -771,8 +812,10 @@ async def main(argv: list[str] | None = None) -> None:
         timeout_seconds,
         display,
         config=config,
+        agent_channel=approval_channel,
     )
     agent = await builder.build()
+    await approval_channel.start()
     mcp_state = MCPRuntimeState(
         config_provider=config_provider,
         config=config,
@@ -786,50 +829,56 @@ async def main(argv: list[str] | None = None) -> None:
         http_client_options={"timeout": timeout_seconds},
     )
 
-    if args.demo:
-        script_path = Path(args.demo)
-        lines = load_script_lines(script_path)
-        await run_cli_loop(
-            lines,
-            agent=agent,
-            model=model,
-            display=display,
-            mcp_state=mcp_state,
-        )
-        return
+    try:
+        if args.demo:
+            script_path = Path(args.demo)
+            lines = load_script_lines(script_path)
+            await run_cli_loop(
+                lines,
+                agent=agent,
+                model=model,
+                display=display,
+                mcp_state=mcp_state,
+                approval_client=approval_client,
+            )
+            return
 
-    if args.script:
-        script_path = Path(args.script)
-        lines = load_script_lines(script_path)
-        await run_cli_loop(
-            lines,
-            agent=agent,
-            model=model,
-            display=display,
-            mcp_state=mcp_state,
-        )
-        return
+        if args.script:
+            script_path = Path(args.script)
+            lines = load_script_lines(script_path)
+            await run_cli_loop(
+                lines,
+                agent=agent,
+                model=model,
+                display=display,
+                mcp_state=mcp_state,
+                approval_client=approval_client,
+            )
+            return
 
-    display.info("type /help for commands. /quit to exit.")
-    cli_state = CLISessionState()
-    while True:
-        try:
-            raw = input("dare> ").strip()
-        except (EOFError, KeyboardInterrupt):
-            break
-        if not raw:
-            continue
-        cli_state, quit_requested = await run_cli_loop(
-            [raw],
-            agent=agent,
-            model=model,
-            display=display,
-            mcp_state=mcp_state,
-            state=cli_state,
-            background_execute=True,
-        )
-        if quit_requested:
-            break
+        display.info("type /help for commands. /quit to exit.")
+        cli_state = CLISessionState()
+        while True:
+            try:
+                raw = input("dare> ").strip()
+            except (EOFError, KeyboardInterrupt):
+                break
+            if not raw:
+                continue
+            cli_state, quit_requested = await run_cli_loop(
+                [raw],
+                agent=agent,
+                model=model,
+                display=display,
+                mcp_state=mcp_state,
+                approval_client=approval_client,
+                state=cli_state,
+                background_execute=True,
+            )
+            if quit_requested:
+                break
+    finally:
+        await approval_channel.stop()
 
 
 if __name__ == "__main__":

--- a/examples/06-dare-coding-agent-mcp/README.md
+++ b/examples/06-dare-coding-agent-mcp/README.md
@@ -69,7 +69,7 @@ MCP server 定义在 `.dare/mcp/local_math.json`：
 - `/reject`：取消待审批计划
 - `/status`：查看当前状态
 - `/approvals list`：查看待审批请求与当前审批规则
-- `/approvals poll [timeout_ms=30000]`：阻塞等待下一个待审批请求（无请求则超时返回）
+- `/approvals poll [timeout_ms=30000] [session_id=...]`：阻塞等待下一个待审批请求（可按 session 过滤）
 - `/approvals grant <request_id> [scope=workspace] [matcher=exact_params] [matcher_value=...]`：批准请求并可写入规则
 - `/approvals deny <request_id> [scope=once] [matcher=exact_params] [matcher_value=...]`：拒绝请求并可写入规则
 - `/approvals revoke <rule_id>`：撤销审批规则

--- a/examples/06-dare-coding-agent-mcp/cli.py
+++ b/examples/06-dare-coding-agent-mcp/cli.py
@@ -28,8 +28,8 @@ from dare_framework.event.kernel import IEventLog
 from dare_framework.event.types import Event, RuntimeSnapshot
 from dare_framework.model import OpenRouterModelAdapter
 from dare_framework.plan import DefaultPlanner, DefaultRemediator, Task
-from dare_framework.tool.action_handler import ApprovalsActionHandler
 from dare_framework.tool._internal.tools import ReadFileTool, RunCommandTool, SearchCodeTool, WriteFileTool
+from dare_framework.transport import AgentChannel, DirectClientChannel, EnvelopeKind, TransportEnvelope, new_envelope_id
 from dare_framework.transport.interaction.resource_action import ResourceAction
 
 from validators.file_validator import FileExistsValidator
@@ -290,6 +290,8 @@ async def build_agent(
     timeout_seconds: float,
     display: CLIDisplay,
     config: Config,
+    *,
+    agent_channel: AgentChannel | None = None,
 ) -> Any:
     model = OpenRouterModelAdapter(
         model=model_name,
@@ -316,6 +318,8 @@ async def build_agent(
         .with_remediator(DefaultRemediator(model, verbose=False))
         .with_event_log(event_log)
     )
+    if agent_channel is not None:
+        builder = builder.with_agent_channel(agent_channel)
 
     agent = await builder.build()
     return agent
@@ -521,17 +525,43 @@ async def _handle_mcp_command(
 
 def _approvals_usage(display: CLIDisplay) -> None:
     display.info("/approvals list")
-    display.info("/approvals poll [timeout_ms=30000]")
+    display.info("/approvals poll [timeout_ms=30000] [session_id=...]")
     display.info("/approvals grant <request_id> [scope=workspace] [matcher=exact_params] [matcher_value=...]")
     display.info("/approvals deny <request_id> [scope=once] [matcher=exact_params] [matcher_value=...]")
     display.info("/approvals revoke <rule_id>")
 
 
-def _resolve_approvals_handler(agent: Any) -> ApprovalsActionHandler | None:
-    approval_manager = getattr(agent, "_approval_manager", None)
-    if approval_manager is None:
-        return None
-    return ApprovalsActionHandler(approval_manager)
+async def _invoke_approval_action(
+    approval_client: DirectClientChannel,
+    action: ResourceAction,
+    *,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    request = TransportEnvelope(
+        id=new_envelope_id(),
+        kind=EnvelopeKind.ACTION,
+        payload=action.value,
+        meta=dict(params or {}),
+    )
+    response = await approval_client.ask(request, timeout=30.0)
+    payload = response.payload
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"unexpected action response payload: {payload!r}")
+
+    event_type = response.event_type
+    if not isinstance(event_type, str) or not event_type:
+        raise RuntimeError("invalid action response: missing event_type")
+    if event_type == "error":
+        raise RuntimeError(str(payload.get("reason") or payload.get("error") or "action failed"))
+
+    resp = payload.get("resp")
+    if not isinstance(resp, dict):
+        raise RuntimeError(f"unexpected action response shape: {payload!r}")
+
+    result = resp.get("result")
+    if not isinstance(result, dict):
+        raise RuntimeError(f"unexpected action result shape: {payload!r}")
+    return result
 
 
 def _parse_key_value_args(tokens: list[str]) -> tuple[list[str], dict[str, str]]:
@@ -561,15 +591,23 @@ def _build_approval_action_params(
     return params
 
 
+def _build_approval_poll_params(trailing_args: list[str]) -> dict[str, Any]:
+    _positional, options = _parse_key_value_args(trailing_args)
+    params: dict[str, Any] = {}
+    for key in ("timeout_ms", "timeout_seconds", "session_id"):
+        if key in options and options[key]:
+            params[key] = options[key]
+    return params
+
+
 async def _handle_approvals_command(
     args: list[str],
     *,
-    agent: Any,
+    approval_client: DirectClientChannel | None,
     display: CLIDisplay,
 ) -> None:
-    handler = _resolve_approvals_handler(agent)
-    if handler is None:
-        display.warn("approval manager unavailable on current agent")
+    if approval_client is None:
+        display.warn("approval transport unavailable")
         return
     if not args:
         _approvals_usage(display)
@@ -578,7 +616,7 @@ async def _handle_approvals_command(
     subcommand = args[0].lower()
     try:
         if subcommand == "list":
-            result = await handler.invoke(ResourceAction.APPROVALS_LIST)
+            result = await _invoke_approval_action(approval_client, ResourceAction.APPROVALS_LIST)
             pending = result.get("pending", [])
             rules = result.get("rules", [])
             display.info(f"pending={len(pending)} rules={len(rules)}")
@@ -586,12 +624,12 @@ async def _handle_approvals_command(
             return
 
         if subcommand == "poll":
-            _positional, options = _parse_key_value_args(args[1:])
-            params: dict[str, Any] = {}
-            for key in ("timeout_ms", "timeout_seconds"):
-                if key in options and options[key]:
-                    params[key] = options[key]
-            result = await handler.invoke(ResourceAction.APPROVALS_POLL, **params)
+            params = _build_approval_poll_params(args[1:])
+            result = await _invoke_approval_action(
+                approval_client,
+                ResourceAction.APPROVALS_POLL,
+                params=params,
+            )
             request = result.get("request")
             if isinstance(request, dict):
                 display.info(f"pending request: {request.get('request_id', '?')}")
@@ -612,7 +650,7 @@ async def _handle_approvals_command(
                 else ResourceAction.APPROVALS_DENY
             )
             params = _build_approval_action_params(request_id=request_id, trailing_args=args[2:])
-            result = await handler.invoke(action, **params)
+            result = await _invoke_approval_action(approval_client, action, params=params)
             display.ok(f"{subcommand} applied: {request_id}")
             print(json.dumps(result, ensure_ascii=False, indent=2), flush=True)
             return
@@ -623,9 +661,10 @@ async def _handle_approvals_command(
                 _approvals_usage(display)
                 return
             rule_id = args[1]
-            result = await handler.invoke(
+            result = await _invoke_approval_action(
+                approval_client,
                 ResourceAction.APPROVALS_REVOKE,
-                rule_id=rule_id,
+                params={"rule_id": rule_id},
             )
             if result.get("removed"):
                 display.ok(f"revoked rule: {rule_id}")
@@ -692,6 +731,7 @@ async def run_cli_loop(
     model: OpenRouterModelAdapter,
     display: CLIDisplay,
     mcp_state: MCPRuntimeState | None = None,
+    approval_client: DirectClientChannel | None = None,
     state: CLISessionState | None = None,
     background_execute: bool = False,
 ) -> tuple[CLISessionState, bool]:
@@ -730,7 +770,7 @@ async def run_cli_loop(
             if cmd.type == CommandType.APPROVALS:
                 await _handle_approvals_command(
                     cmd.args,
-                    agent=agent,
+                    approval_client=approval_client,
                     display=display,
                 )
                 continue
@@ -853,6 +893,8 @@ async def main(argv: list[str] | None = None) -> None:
     else:
         display.warn("No mcp_paths configured. MCP tools will not be loaded by default.")
 
+    approval_client = DirectClientChannel()
+    approval_channel = AgentChannel.build(approval_client)
     agent = await build_agent(
         workspace,
         model_name,
@@ -861,7 +903,9 @@ async def main(argv: list[str] | None = None) -> None:
         timeout_seconds,
         display,
         config,
+        agent_channel=approval_channel,
     )
+    await approval_channel.start()
     mcp_state = MCPRuntimeState(
         config_provider=config_provider,
         config=config,
@@ -876,50 +920,56 @@ async def main(argv: list[str] | None = None) -> None:
         http_client_options={"timeout": timeout_seconds},
     )
 
-    if args.demo:
-        script_path = Path(args.demo)
-        lines = load_script_lines(script_path)
-        await run_cli_loop(
-            lines,
-            agent=agent,
-            model=model,
-            display=display,
-            mcp_state=mcp_state,
-        )
-        return
+    try:
+        if args.demo:
+            script_path = Path(args.demo)
+            lines = load_script_lines(script_path)
+            await run_cli_loop(
+                lines,
+                agent=agent,
+                model=model,
+                display=display,
+                mcp_state=mcp_state,
+                approval_client=approval_client,
+            )
+            return
 
-    if args.script:
-        script_path = Path(args.script)
-        lines = load_script_lines(script_path)
-        await run_cli_loop(
-            lines,
-            agent=agent,
-            model=model,
-            display=display,
-            mcp_state=mcp_state,
-        )
-        return
+        if args.script:
+            script_path = Path(args.script)
+            lines = load_script_lines(script_path)
+            await run_cli_loop(
+                lines,
+                agent=agent,
+                model=model,
+                display=display,
+                mcp_state=mcp_state,
+                approval_client=approval_client,
+            )
+            return
 
-    display.info("type /help for commands. /quit to exit.")
-    cli_state = CLISessionState()
-    while True:
-        try:
-            raw = input("dare> ").strip()
-        except (EOFError, KeyboardInterrupt):
-            break
-        if not raw:
-            continue
-        cli_state, quit_requested = await run_cli_loop(
-            [raw],
-            agent=agent,
-            model=model,
-            display=display,
-            mcp_state=mcp_state,
-            state=cli_state,
-            background_execute=True,
-        )
-        if quit_requested:
-            break
+        display.info("type /help for commands. /quit to exit.")
+        cli_state = CLISessionState()
+        while True:
+            try:
+                raw = input("dare> ").strip()
+            except (EOFError, KeyboardInterrupt):
+                break
+            if not raw:
+                continue
+            cli_state, quit_requested = await run_cli_loop(
+                [raw],
+                agent=agent,
+                model=model,
+                display=display,
+                mcp_state=mcp_state,
+                approval_client=approval_client,
+                state=cli_state,
+                background_execute=True,
+            )
+            if quit_requested:
+                break
+    finally:
+        await approval_channel.stop()
 
 
 if __name__ == "__main__":

--- a/examples/07-tool-approval-memory/README.md
+++ b/examples/07-tool-approval-memory/README.md
@@ -18,7 +18,7 @@ python main.py
 
 ## 你会看到什么
 
-- 第一次 run：先收到 `approval_pending` 通知并打印 `pending request: ...`，随后调用 `approvals:grant`。
+- 第一次 run：先收到 `event_type=approval.pending` 通知并打印 `pending request: ...`，随后调用 `approvals:grant`。
 - 第一次 run 同时演示 `approvals:poll`（控制面阻塞拉取待审批请求）。
 - 第二次 run：`pending_count=0`（自动放行）。
 - 撤销规则后第三次 run：再次出现 `pending request after revoke: ...`。
@@ -30,7 +30,7 @@ python main.py
 - 通道侧：`DirectClientChannel + AgentChannel`
 - 审批 action：
   - `approvals:list`
-  - `approvals:poll`
+  - `approvals:poll`（可选 `session_id` 过滤）
   - `approvals:grant`
   - `approvals:revoke`
 - 规则持久化路径：

--- a/examples/07-tool-approval-memory/main.py
+++ b/examples/07-tool-approval-memory/main.py
@@ -117,7 +117,10 @@ async def _invoke_action(
     payload = response.payload
     if not isinstance(payload, dict):
         raise RuntimeError(f"unexpected action response payload: {payload!r}")
-    if payload.get("type") == "error":
+    event_type = response.event_type
+    if not isinstance(event_type, str) or not event_type:
+        raise RuntimeError("invalid action response: missing event_type")
+    if event_type == "error":
         raise RuntimeError(f"action failed ({action_id}): {payload.get('reason')}")
 
     resp = payload.get("resp")
@@ -143,7 +146,8 @@ async def _wait_for_pending_request_id(
         payload = envelope.payload
         if not isinstance(payload, dict):
             continue
-        if payload.get("type") != "approval_pending":
+        event_type = envelope.event_type
+        if event_type != "approval.pending":
             continue
         resp = payload.get("resp")
         if not isinstance(resp, dict):
@@ -151,7 +155,7 @@ async def _wait_for_pending_request_id(
         request = resp.get("request")
         if isinstance(request, dict) and isinstance(request.get("request_id"), str):
             return request["request_id"]
-    raise TimeoutError("approval_pending event was not received in time")
+    raise TimeoutError("approval.pending event was not received in time")
 
 
 def _new_prompt_envelope(prompt: str) -> TransportEnvelope:
@@ -166,7 +170,8 @@ def _extract_run_success(response: TransportEnvelope) -> bool:
     payload = response.payload
     if not isinstance(payload, dict):
         return False
-    if payload.get("type") == "error":
+    event_type = response.event_type
+    if event_type != "result":
         return False
     raw_success = payload.get("success")
     if isinstance(raw_success, bool):

--- a/tests/unit/test_agent_event_transport_hook.py
+++ b/tests/unit/test_agent_event_transport_hook.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dare_framework.hook._internal.agent_event_transport_hook import AgentEventTransportHook
+from dare_framework.hook.types import HookPhase
+from dare_framework.transport import TransportEventType
+
+
+class _RecordingTransport:
+    def __init__(self) -> None:
+        self.sent: list[Any] = []
+
+    async def send(self, msg: Any) -> None:
+        self.sent.append(msg)
+
+
+@pytest.mark.asyncio
+async def test_agent_event_transport_hook_sets_event_type() -> None:
+    transport = _RecordingTransport()
+    hook = AgentEventTransportHook(transport)
+
+    await hook.invoke(HookPhase.BEFORE_PLAN, payload={"task_id": "task-1"})
+
+    assert len(transport.sent) == 1
+    envelope = transport.sent[0]
+    assert envelope.event_type == TransportEventType.HOOK.value
+    assert isinstance(envelope.payload, dict)
+    assert envelope.payload.get("phase") == HookPhase.BEFORE_PLAN.value

--- a/tests/unit/test_base_agent_transport_contract.py
+++ b/tests/unit/test_base_agent_transport_contract.py
@@ -8,7 +8,7 @@ import pytest
 from dare_framework.agent.base_agent import BaseAgent
 from dare_framework.agent.status import AgentStatus
 from dare_framework.plan.types import RunResult
-from dare_framework.transport import EnvelopeKind, TransportEnvelope
+from dare_framework.transport import EnvelopeKind, TransportEnvelope, TransportEventType
 
 
 class _CaptureAgent(BaseAgent):
@@ -224,6 +224,7 @@ async def test_transport_loop_accepts_batched_messages_from_poll() -> None:
     assert agent.seen_tasks == ["first", "second"]
     assert len(channel._sent) == 2
     assert [envelope.reply_to for envelope in channel._sent] == ["m1", "m2"]
+    assert all(envelope.event_type == TransportEventType.RESULT.value for envelope in channel._sent)
 
 
 @pytest.mark.asyncio
@@ -238,12 +239,18 @@ async def test_transport_loop_returns_structured_error_for_invalid_message_paylo
     error_payloads = [
         envelope.payload
         for envelope in channel._sent
-        if isinstance(envelope.payload, dict) and envelope.payload.get("type") == "error"
+        if getattr(envelope, "event_type", None) == TransportEventType.ERROR.value and isinstance(envelope.payload, dict)
     ]
     assert len(error_payloads) == 1
     payload = error_payloads[0]
     assert payload.get("code") == "INVALID_MESSAGE_PAYLOAD"
     assert payload.get("kind") == "message"
+    error_envelope = next(
+        envelope
+        for envelope in channel._sent
+        if getattr(envelope, "event_type", None) == TransportEventType.ERROR.value and isinstance(envelope.payload, dict)
+    )
+    assert error_envelope.event_type == TransportEventType.ERROR.value
 
 
 @pytest.mark.asyncio
@@ -254,12 +261,15 @@ async def test_transport_loop_returns_structured_error_when_execute_raises() -> 
 
     await agent._run_transport_loop()
 
-    error_payloads = [
-        envelope.payload
+    error_envelopes = [
+        envelope
         for envelope in channel._sent
-        if isinstance(envelope.payload, dict) and envelope.payload.get("type") == "error"
+        if getattr(envelope, "event_type", None) == TransportEventType.ERROR.value and isinstance(envelope.payload, dict)
     ]
-    assert len(error_payloads) == 1
-    payload = error_payloads[0]
+    assert len(error_envelopes) == 1
+    error_envelope = error_envelopes[0]
+    assert error_envelope.event_type == TransportEventType.ERROR.value
+    payload = error_envelope.payload
+    assert isinstance(payload, dict)
     assert payload.get("code") == "AGENT_EXECUTION_FAILED"
     assert "simulated model timeout" in str(payload.get("reason"))

--- a/tests/unit/test_dare_agent_hook_transport_boundary.py
+++ b/tests/unit/test_dare_agent_hook_transport_boundary.py
@@ -10,7 +10,7 @@ from dare_framework.config import Config
 from dare_framework.context import Context
 from dare_framework.model.types import ModelInput, ModelResponse
 from dare_framework.tool.types import ToolResult
-from dare_framework.transport import AgentChannel, TransportEnvelope
+from dare_framework.transport import AgentChannel, TransportEnvelope, TransportEventType
 
 
 class _Model:
@@ -86,7 +86,7 @@ async def test_dare_agent_does_not_emit_hook_messages_without_transport_hook() -
     hook_payloads = [
         envelope.payload
         for envelope in transport.sent
-        if isinstance(envelope.payload, dict) and envelope.payload.get("type") == "hook"
+        if getattr(envelope, "event_type", None) == TransportEventType.HOOK.value
     ]
     assert hook_payloads == []
 

--- a/tests/unit/test_examples_cli.py
+++ b/tests/unit/test_examples_cli.py
@@ -4,15 +4,19 @@ import asyncio
 import contextlib
 from pathlib import Path
 import sys
+from typing import Any
 
 import pytest
 
+from dare_framework.tool.action_handler import ApprovalsActionHandler
 from dare_framework.tool._internal.control.approval_manager import (
     ApprovalDecision,
     ApprovalEvaluationStatus,
     JsonApprovalRuleStore,
     ToolApprovalManager,
 )
+from dare_framework.transport import EnvelopeKind, TransportEnvelope
+from dare_framework.transport.interaction.resource_action import ResourceAction
 
 
 def _resolve_example_dir() -> Path:
@@ -99,6 +103,52 @@ class _CaptureDisplay:
         return
 
 
+class _HandlerBackedApprovalClient:
+    """Minimal ask-capable client shim backed by the real approvals action handler."""
+
+    def __init__(self, manager: ToolApprovalManager) -> None:
+        self._handler = ApprovalsActionHandler(manager)
+
+    async def ask(self, req: TransportEnvelope, timeout: float = 30.0) -> TransportEnvelope:
+        _ = timeout
+        action = ResourceAction(str(req.payload))
+        result = await self._handler.invoke(action, **dict(req.meta))
+        return TransportEnvelope(
+            id=f"resp-{req.id}",
+            reply_to=req.id,
+            kind=EnvelopeKind.MESSAGE,
+            event_type="result",
+            payload={"resp": {"result": result}},
+        )
+
+
+class _CaptureApprovalClient:
+    def __init__(self) -> None:
+        self.last_meta: dict[str, Any] | None = None
+
+    async def ask(self, req: TransportEnvelope, timeout: float = 30.0) -> TransportEnvelope:
+        _ = timeout
+        self.last_meta = dict(req.meta)
+        return TransportEnvelope(
+            id=f"resp-{req.id}",
+            reply_to=req.id,
+            kind=EnvelopeKind.MESSAGE,
+            event_type="result",
+            payload={"resp": {"result": {"request": None}}},
+        )
+
+
+class _MissingEventTypeApprovalClient:
+    async def ask(self, req: TransportEnvelope, timeout: float = 30.0) -> TransportEnvelope:
+        _ = timeout
+        return TransportEnvelope(
+            id=f"resp-{req.id}",
+            reply_to=req.id,
+            kind=EnvelopeKind.MESSAGE,
+            payload={"resp": {"result": {"request": None}}},
+        )
+
+
 @pytest.mark.asyncio
 async def test_handle_approvals_command_list_and_grant(tmp_path: Path) -> None:
     manager = ToolApprovalManager(
@@ -115,21 +165,19 @@ async def test_handle_approvals_command_list_and_grant(tmp_path: Path) -> None:
     assert evaluation.request is not None
     request_id = evaluation.request.request_id
 
-    class _FakeAgent:
-        _approval_manager = manager
-
     display = _CaptureDisplay()
+    approval_client = _HandlerBackedApprovalClient(manager)
 
     await cli._handle_approvals_command(  # type: ignore[attr-defined]
         ["list"],
-        agent=_FakeAgent(),
+        approval_client=approval_client,
         display=display,
     )
     assert any("pending" in msg for level, msg in display.messages if level == "info")
 
     await cli._handle_approvals_command(  # type: ignore[attr-defined]
         ["poll", "timeout_ms=10"],
-        agent=_FakeAgent(),
+        approval_client=approval_client,
         display=display,
     )
     assert any("pending request:" in msg for level, msg in display.messages if level == "info")
@@ -137,10 +185,35 @@ async def test_handle_approvals_command_list_and_grant(tmp_path: Path) -> None:
     wait_task = asyncio.create_task(manager.wait_for_resolution(request_id))
     await cli._handle_approvals_command(  # type: ignore[attr-defined]
         ["grant", request_id, "scope=workspace", "matcher=exact_params"],
-        agent=_FakeAgent(),
+        approval_client=approval_client,
         display=display,
     )
     assert await wait_task == ApprovalDecision.ALLOW
+
+
+@pytest.mark.asyncio
+async def test_handle_approvals_poll_forwards_session_filter() -> None:
+    display = _CaptureDisplay()
+    approval_client = _CaptureApprovalClient()
+    await cli._handle_approvals_command(  # type: ignore[attr-defined]
+        ["poll", "timeout_ms=10", "session_id=session-42"],
+        approval_client=approval_client,
+        display=display,
+    )
+    assert approval_client.last_meta is not None
+    assert approval_client.last_meta.get("session_id") == "session-42"
+
+
+@pytest.mark.asyncio
+async def test_handle_approvals_command_requires_event_type_in_response() -> None:
+    display = _CaptureDisplay()
+    approval_client = _MissingEventTypeApprovalClient()
+    await cli._handle_approvals_command(  # type: ignore[attr-defined]
+        ["list"],
+        approval_client=approval_client,
+        display=display,
+    )
+    assert any("missing event_type" in msg for level, msg in display.messages if level == "error")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_examples_cli_mcp.py
+++ b/tests/unit/test_examples_cli_mcp.py
@@ -4,15 +4,19 @@ import asyncio
 import importlib.util
 from pathlib import Path
 import sys
+from typing import Any
 
 import pytest
 
+from dare_framework.tool.action_handler import ApprovalsActionHandler
 from dare_framework.tool._internal.control.approval_manager import (
     ApprovalDecision,
     ApprovalEvaluationStatus,
     JsonApprovalRuleStore,
     ToolApprovalManager,
 )
+from dare_framework.transport import EnvelopeKind, TransportEnvelope
+from dare_framework.transport.interaction.resource_action import ResourceAction
 
 
 def _load_cli_module(module_name: str, relative_cli_path: str):
@@ -64,6 +68,52 @@ class _CaptureDisplay:
         return
 
 
+class _HandlerBackedApprovalClient:
+    """Minimal ask-capable client shim backed by the real approvals action handler."""
+
+    def __init__(self, manager: ToolApprovalManager) -> None:
+        self._handler = ApprovalsActionHandler(manager)
+
+    async def ask(self, req: TransportEnvelope, timeout: float = 30.0) -> TransportEnvelope:
+        _ = timeout
+        action = ResourceAction(str(req.payload))
+        result = await self._handler.invoke(action, **dict(req.meta))
+        return TransportEnvelope(
+            id=f"resp-{req.id}",
+            reply_to=req.id,
+            kind=EnvelopeKind.MESSAGE,
+            event_type="result",
+            payload={"resp": {"result": result}},
+        )
+
+
+class _CaptureApprovalClient:
+    def __init__(self) -> None:
+        self.last_meta: dict[str, Any] | None = None
+
+    async def ask(self, req: TransportEnvelope, timeout: float = 30.0) -> TransportEnvelope:
+        _ = timeout
+        self.last_meta = dict(req.meta)
+        return TransportEnvelope(
+            id=f"resp-{req.id}",
+            reply_to=req.id,
+            kind=EnvelopeKind.MESSAGE,
+            event_type="result",
+            payload={"resp": {"result": {"request": None}}},
+        )
+
+
+class _MissingEventTypeApprovalClient:
+    async def ask(self, req: TransportEnvelope, timeout: float = 30.0) -> TransportEnvelope:
+        _ = timeout
+        return TransportEnvelope(
+            id=f"resp-{req.id}",
+            reply_to=req.id,
+            kind=EnvelopeKind.MESSAGE,
+            payload={"resp": {"result": {"request": None}}},
+        )
+
+
 @pytest.mark.asyncio
 async def test_handle_approvals_command_list_and_grant_mcp_cli(tmp_path: Path) -> None:
     cli_mcp = _load_cli_module(
@@ -84,20 +134,18 @@ async def test_handle_approvals_command_list_and_grant_mcp_cli(tmp_path: Path) -
     assert evaluation.request is not None
     request_id = evaluation.request.request_id
 
-    class _FakeAgent:
-        _approval_manager = manager
-
     display = _CaptureDisplay()
+    approval_client = _HandlerBackedApprovalClient(manager)
     await cli_mcp._handle_approvals_command(  # type: ignore[attr-defined]
         ["list"],
-        agent=_FakeAgent(),
+        approval_client=approval_client,
         display=display,
     )
     assert any("pending" in msg for level, msg in display.messages if level == "info")
 
     await cli_mcp._handle_approvals_command(  # type: ignore[attr-defined]
         ["poll", "timeout_ms=10"],
-        agent=_FakeAgent(),
+        approval_client=approval_client,
         display=display,
     )
     assert any("pending request:" in msg for level, msg in display.messages if level == "info")
@@ -105,10 +153,43 @@ async def test_handle_approvals_command_list_and_grant_mcp_cli(tmp_path: Path) -
     wait_task = asyncio.create_task(manager.wait_for_resolution(request_id))
     await cli_mcp._handle_approvals_command(  # type: ignore[attr-defined]
         ["grant", request_id, "scope=workspace", "matcher=exact_params"],
-        agent=_FakeAgent(),
+        approval_client=approval_client,
         display=display,
     )
     assert await wait_task == ApprovalDecision.ALLOW
+
+
+@pytest.mark.asyncio
+async def test_handle_approvals_poll_forwards_session_filter_mcp_cli() -> None:
+    cli_mcp = _load_cli_module(
+        "examples_06_cli_poll_filter",
+        "examples/06-dare-coding-agent-mcp/cli.py",
+    )
+    display = _CaptureDisplay()
+    approval_client = _CaptureApprovalClient()
+    await cli_mcp._handle_approvals_command(  # type: ignore[attr-defined]
+        ["poll", "timeout_ms=10", "session_id=session-42"],
+        approval_client=approval_client,
+        display=display,
+    )
+    assert approval_client.last_meta is not None
+    assert approval_client.last_meta.get("session_id") == "session-42"
+
+
+@pytest.mark.asyncio
+async def test_handle_approvals_command_requires_event_type_in_response_mcp_cli() -> None:
+    cli_mcp = _load_cli_module(
+        "examples_06_cli_missing_event_type",
+        "examples/06-dare-coding-agent-mcp/cli.py",
+    )
+    display = _CaptureDisplay()
+    approval_client = _MissingEventTypeApprovalClient()
+    await cli_mcp._handle_approvals_command(  # type: ignore[attr-defined]
+        ["list"],
+        approval_client=approval_client,
+        display=display,
+    )
+    assert any("missing event_type" in msg for level, msg in display.messages if level == "error")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_five_layer_agent.py
+++ b/tests/unit/test_five_layer_agent.py
@@ -517,10 +517,10 @@ class TestNoPlannerToolExecution:
         request_id: str | None = None
         for _ in range(100):
             for envelope in transport.sent:
+                if getattr(envelope, "event_type", None) != "approval.pending":
+                    continue
                 payload = getattr(envelope, "payload", None)
                 if not isinstance(payload, dict):
-                    continue
-                if payload.get("type") != "approval_pending":
                     continue
                 resp = payload.get("resp")
                 if not isinstance(resp, dict):

--- a/tests/unit/test_tool_approval_action_handler.py
+++ b/tests/unit/test_tool_approval_action_handler.py
@@ -102,3 +102,27 @@ async def test_approvals_action_handler_poll_timeout_returns_null_request(manage
 
     polled = await handler.invoke(ResourceAction.APPROVALS_POLL, timeout_seconds=0.05)
     assert polled["request"] is None
+
+
+@pytest.mark.asyncio
+async def test_approvals_action_handler_poll_filters_by_session_id(manager) -> None:
+    handler = ApprovalsActionHandler(manager)
+    first = await manager.evaluate(
+        capability_id="run_command",
+        params={"command": "echo session-a"},
+        session_id="session-a",
+        reason="Tool run_command requires approval",
+    )
+    second = await manager.evaluate(
+        capability_id="run_command",
+        params={"command": "echo session-b"},
+        session_id="session-b",
+        reason="Tool run_command requires approval",
+    )
+    assert first.request is not None
+    assert second.request is not None
+
+    polled = await handler.invoke(ResourceAction.APPROVALS_POLL, session_id="session-b")
+    request = polled["request"]
+    assert isinstance(request, dict)
+    assert request["request_id"] == second.request.request_id

--- a/tests/unit/test_tool_approval_manager.py
+++ b/tests/unit/test_tool_approval_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 
 import pytest
@@ -164,6 +165,71 @@ async def test_poll_pending_returns_next_request_when_available(manager) -> None
     polled = await manager.poll_pending()
     assert polled is not None
     assert polled.request_id == first.request.request_id
+
+
+@pytest.mark.asyncio
+async def test_poll_pending_filters_by_session_id(manager) -> None:
+    first = await manager.evaluate(
+        capability_id="run_command",
+        params={"command": "echo session-a"},
+        session_id="session-a",
+        reason="Tool run_command requires approval",
+    )
+    second = await manager.evaluate(
+        capability_id="run_command",
+        params={"command": "echo session-b"},
+        session_id="session-b",
+        reason="Tool run_command requires approval",
+    )
+    assert first.request is not None
+    assert second.request is not None
+
+    polled = await manager.poll_pending(session_id="session-b")
+    assert polled is not None
+    assert polled.request_id == second.request.request_id
+
+
+@pytest.mark.asyncio
+async def test_poll_pending_session_filter_timeout_returns_none(manager) -> None:
+    await manager.evaluate(
+        capability_id="run_command",
+        params={"command": "echo session-a"},
+        session_id="session-a",
+        reason="Tool run_command requires approval",
+    )
+
+    polled = await manager.poll_pending(session_id="session-miss", timeout_seconds=0.05)
+    assert polled is None
+
+
+@pytest.mark.asyncio
+async def test_poll_pending_session_filter_waiter_does_not_busy_loop_on_unrelated_pending(manager, monkeypatch) -> None:
+    await manager.evaluate(
+        capability_id="run_command",
+        params={"command": "echo session-a"},
+        session_id="session-a",
+        reason="Tool run_command requires approval",
+    )
+
+    call_count = 0
+    original = manager._oldest_pending_locked
+
+    def tracked_oldest_pending(*, session_id: str | None = None):
+        nonlocal call_count
+        call_count += 1
+        return original(session_id=session_id)
+
+    monkeypatch.setattr(manager, "_oldest_pending_locked", tracked_oldest_pending)
+    waiter = asyncio.create_task(manager.poll_pending(session_id="session-miss"))
+    await asyncio.sleep(0.05)
+
+    assert waiter.done() is False
+    # A healthy waiter should sleep on condition changes instead of tight-loop polling.
+    assert call_count < 30
+
+    waiter.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await waiter
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_transport_adapters.py
+++ b/tests/unit/test_transport_adapters.py
@@ -1,9 +1,11 @@
 import asyncio
+import json
 
 import pytest
 
+from dare_framework.transport import PollableClientChannel
 from dare_framework.transport._internal.adapters import DirectClientChannel, StdioClientChannel, WebSocketClientChannel
-from dare_framework.transport.types import EnvelopeKind, TransportEnvelope
+from dare_framework.transport.types import EnvelopeKind, TransportEnvelope, TransportEventType
 
 
 @pytest.mark.asyncio
@@ -34,6 +36,14 @@ class _DummyWS:
         return None
 
 
+class _CaptureWS:
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+
+    async def send(self, msg: str) -> None:
+        self.sent.append(msg)
+
+
 @pytest.mark.asyncio
 async def test_websocket_requires_explicit_kind() -> None:
     ws = WebSocketClientChannel(_DummyWS())
@@ -45,6 +55,24 @@ async def test_websocket_requires_explicit_kind() -> None:
 
     with pytest.raises(ValueError, match="kind"):
         await ws.handle_ws_message({"id": "req-1", "payload": "hello"})
+
+
+@pytest.mark.asyncio
+async def test_websocket_serializer_includes_event_type() -> None:
+    ws = _CaptureWS()
+    channel = WebSocketClientChannel(ws)
+    receiver = channel.agent_envelope_receiver()
+    await receiver(
+        TransportEnvelope(
+            id="evt-1",
+            kind=EnvelopeKind.MESSAGE,
+            event_type=TransportEventType.RESULT.value,
+            payload={"ok": True},
+        )
+    )
+    assert ws.sent
+    data = json.loads(ws.sent[0])
+    assert data["event_type"] == TransportEventType.RESULT.value
 
 
 @pytest.mark.asyncio
@@ -61,15 +89,15 @@ async def test_direct_client_channel_poll_receives_unmatched_agent_messages() ->
         TransportEnvelope(
             id="event-1",
             kind=EnvelopeKind.MESSAGE,
-            payload={"type": "approval_pending", "request_id": "req-1"},
+            event_type=TransportEventType.APPROVAL_PENDING.value,
+            payload={"request_id": "req-1"},
         )
     )
 
     polled = await channel.poll(timeout=0.2)
     assert polled is not None
     assert polled.id == "event-1"
-    assert isinstance(polled.payload, dict)
-    assert polled.payload.get("type") == "approval_pending"
+    assert polled.event_type == TransportEventType.APPROVAL_PENDING.value
 
 
 @pytest.mark.asyncio
@@ -82,3 +110,46 @@ async def test_direct_client_channel_poll_times_out_when_empty() -> None:
     channel.attach_agent_envelope_sender(sender)
     polled = await channel.poll(timeout=0.05)
     assert polled is None
+
+
+def test_direct_client_channel_matches_pollable_protocol() -> None:
+    channel = DirectClientChannel()
+    assert isinstance(channel, PollableClientChannel)
+
+
+@pytest.mark.asyncio
+async def test_stdio_receiver_uses_event_type_without_legacy_payload_type(capsys) -> None:
+    channel = StdioClientChannel()
+    receiver = channel.agent_envelope_receiver()
+    await receiver(
+        TransportEnvelope(
+            id="evt-2",
+            kind=EnvelopeKind.MESSAGE,
+            event_type=TransportEventType.APPROVAL_PENDING.value,
+            payload={"resp": {"request": {"request_id": "req-42"}}},
+        )
+    )
+    captured = capsys.readouterr()
+    assert "approval pending: request_id=req-42" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_stdio_receiver_does_not_route_by_payload_type_without_event_type(capsys) -> None:
+    channel = StdioClientChannel()
+    receiver = channel.agent_envelope_receiver()
+
+    await receiver(
+        TransportEnvelope(
+            id="evt-legacy-result",
+            kind=EnvelopeKind.MESSAGE,
+            payload={
+                "type": "result",
+                "kind": "message",
+                "resp": {"output": "hello"},
+            },
+        )
+    )
+
+    captured = capsys.readouterr()
+    assert "Assistant: {'type': 'result'" in captured.out
+    assert "Assistant: hello" not in captured.out

--- a/tests/unit/test_transport_channel.py
+++ b/tests/unit/test_transport_channel.py
@@ -3,7 +3,13 @@ import inspect
 
 import pytest
 
-from dare_framework.transport import AgentChannel, EnvelopeKind, TransportEnvelope, new_envelope_id
+from dare_framework.transport import (
+    AgentChannel,
+    EnvelopeKind,
+    TransportEnvelope,
+    TransportEventType,
+    new_envelope_id,
+)
 from dare_framework.transport.interaction.resource_action import ResourceAction
 from dare_framework.transport.interaction.control_handler import AgentControlHandler
 from dare_framework.transport.interaction.dispatcher import ActionHandlerDispatcher
@@ -290,9 +296,9 @@ async def test_invalid_control_payload_returns_structured_error() -> None:
         await channel.stop()
 
     assert len(seen) == 1
+    assert seen[0].event_type == TransportEventType.ERROR.value
     payload = seen[0].payload
     assert isinstance(payload, dict)
-    assert payload.get("type") == "error"
     assert payload.get("kind") == "control"
     assert payload.get("ok") is False
     assert payload.get("code") == "INVALID_CONTROL_PAYLOAD"
@@ -326,9 +332,9 @@ async def test_invalid_message_payload_returns_structured_error_and_is_not_enque
         await channel.stop()
 
     assert len(seen) == 1
+    assert seen[0].event_type == TransportEventType.ERROR.value
     payload = seen[0].payload
     assert isinstance(payload, dict)
-    assert payload.get("type") == "error"
     assert payload.get("kind") == "message"
     assert payload.get("ok") is False
     assert payload.get("code") == "INVALID_MESSAGE_PAYLOAD"
@@ -377,9 +383,9 @@ async def test_action_timeout_returns_structured_error_and_channel_keeps_process
         await channel.stop()
 
     assert msg.payload == "hello-after-timeout"
+    assert seen[0].event_type == TransportEventType.ERROR.value
     timeout_payload = seen[0].payload
     assert isinstance(timeout_payload, dict)
-    assert timeout_payload.get("type") == "error"
     assert timeout_payload.get("kind") == "action"
     assert timeout_payload.get("ok") is False
     assert timeout_payload.get("code") == "ACTION_TIMEOUT"

--- a/tests/unit/test_transport_types.py
+++ b/tests/unit/test_transport_types.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from dare_framework.transport import normalize_transport_event_type
+from dare_framework.transport.types import EnvelopeKind, TransportEnvelope, TransportEventType
+
+
+def test_transport_envelope_does_not_derive_event_type_from_payload_type() -> None:
+    envelope = TransportEnvelope(
+        id="evt-no-derive",
+        kind=EnvelopeKind.MESSAGE,
+        payload={"type": "result"},
+    )
+    assert envelope.event_type is None
+
+
+def test_transport_envelope_normalizes_legacy_event_type() -> None:
+    envelope = TransportEnvelope(
+        id="evt-legacy",
+        kind="message",
+        event_type="approval_pending",
+        payload={"type": "approval_pending"},
+    )
+    assert envelope.kind == EnvelopeKind.MESSAGE
+    assert envelope.event_type == TransportEventType.APPROVAL_PENDING.value
+
+
+def test_transport_envelope_rejects_empty_event_type() -> None:
+    with pytest.raises(ValueError, match="event_type must not be empty"):
+        TransportEnvelope(
+            id="evt-empty",
+            kind=EnvelopeKind.MESSAGE,
+            event_type="   ",
+            payload={"type": "result"},
+        )
+
+
+def test_transport_facade_re_exports_event_type_normalizer() -> None:
+    assert normalize_transport_event_type("approval_pending") == TransportEventType.APPROVAL_PENDING.value


### PR DESCRIPTION
## What

- Finalize ADR v2 transport protocol semantics by enforcing explicit envelope-level `event_type` and canonical normalization (`TransportEventType` + `normalize_transport_event_type`).
- Keep `ClientChannel` minimal and introduce `PollableClientChannel` for unsolicited-event polling use cases.
- Remove legacy payload `type` dead fields and legacy routing branches; consumers now route by `event_type` only.
- Route approvals CLI control plane via `DirectClientChannel.ask(ACTION)` instead of accessing internal manager handlers.
- Add `session_id` filtering in approval polling and harden pending-state synchronization.
- Update examples/docs and add focused tests around transport adapters, approval flow, and channel behavior.

## Why

- Keep transport boundaries stable and replaceable across stdio/websocket/direct channels.
- Prevent implicit payload-shape coupling and make event routing auditable/typed.
- Remove control-plane backdoors so all clients follow the same dispatch contract.

## Plan / ADR

- Plan: N/A (this PR is implementation + cleanup continuation)
- ADR: ADR v2 alignment discussed in-thread; code aligns to ADR v2 acceptance criteria.

## Tradeoff

- `DefaultAgentChannel.send()` now drops pre-start outgoing envelopes with warning instead of blocking bounded outbox; this favors non-hanging direct-call safety over buffering before channel start.

## Test Evidence

```bash
pytest tests/unit/test_examples_cli.py tests/unit/test_examples_cli_mcp.py tests/unit/test_base_agent_transport_contract.py
# 20 passed
```

## Open Questions

- Keep `#85` open for history, or close it after this PR is accepted?

---

Supersedes: #85