### PR TITLE
feat(client): improve CLI approvals and logging UX

### DIFF
--- a/client/DESIGN.md
+++ b/client/DESIGN.md
@@ -164,7 +164,7 @@ dare doctor
 ### 7.1 来源
 
 1. CLI flags（最高）
-2. workspace `.dare/config.json`
+2. workspace `.dare/config.json`（覆盖 user）
 3. user `.dare/config.json`
 4. 代码默认值（最低）
 
@@ -172,8 +172,9 @@ dare doctor
 
 1. `workspace_dir`、`user_dir`
 2. `llm.adapter/model/api_key/endpoint/proxy`
-3. `mcp_paths`、`allow_mcps`
-4. `default_prompt_id`
+3. `cli.log_path`
+4. `mcp_paths`、`allow_mcps`
+5. `default_prompt_id`
 
 ### 7.3 一致性原则
 
@@ -183,7 +184,9 @@ CLI 层不自行定义“平行配置模型”，只对 `Config` 做覆盖合并
 
 ### 8.1 输出模式
 
-1. `--output human`（默认）：可读文本。
+1. `--output human`（默认）：终端仅保留交互内容；日志统一落盘到 `cli.log_path`（默认 `./dare.log`）。
+   - `chat` 模式下执行期间默认不重复显示 prompt；仅在任务完成后重新给出 `dare>` 输入提示。
+   - 若执行中触发工具审批，CLI 直接以内联 `approve>` 提示收集 `y/n` 决策，再通过 `approvals:*` action 提交到底层审批管理器。
 2. `--output json`：结构化 JSON，便于自动化集成。
 
 ### 8.2 标准退出码

--- a/client/README.md
+++ b/client/README.md
@@ -53,18 +53,266 @@
 
 ## 配置
 
-默认配置来源：
+### 配置文件位置与覆盖顺序
 
-1. `--workspace` 指定目录下 `.dare/config.json`
-2. `--user-dir` 指定目录下 `.dare/config.json`
-3. CLI flags 覆盖（`--adapter/--model/--api-key/...`）
+默认会读取两个配置文件：
+
+1. `--user-dir` 指定目录下 `.dare/config.json`
+2. `--workspace` 指定目录下 `.dare/config.json`
+3. CLI flags 最终覆盖（`--adapter/--model/--api-key/--endpoint/--max-tokens/...`）
+
+也就是实际优先级是：`user < workspace < CLI flags`。
+
+补充说明：
+
+- 两个配置文件如果不存在，会自动创建为空对象 `{}`。
+- 配置是深合并：字典会逐层合并；标量和数组会被高优先级配置整体覆盖。
+- `--workspace` 默认为当前目录，`--user-dir` 默认为当前用户 home 目录。
 
 > 在受限环境中建议显式传入 `--user-dir`，避免写入不可访问的 home 目录。
 
+首次初始化时，也可以直接参考仓库内的示例文件：
+
+- `/.dare/config.json.example`：OpenAI 最小配置
+- `/.dare/config.openrouter.example.json`：OpenRouter 最小配置
+- `/.dare/config.advanced.example.json`：带 `cli.log_path/endpoint/proxy/max_tokens` 的进阶配置
+
+### 最小可用 LLM 配置
+
+最常见的做法是在 `.dare/config.json` 里写一个 `llm` 段：
+
+```json
+{
+  "llm": {
+    "adapter": "openai",
+    "model": "gpt-4o-mini",
+    "api_key": "sk-..."
+  }
+}
+```
+
+如果你不想把密钥写进配置文件，也可以使用环境变量：
+
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+这时 `config.json` 可以只保留模型相关字段：
+
+```json
+{
+  "llm": {
+    "model": "gpt-4o-mini"
+  }
+}
+```
+
+如果你就在当前仓库里试用 CLI，最省事的起点是：
+
+```bash
+cp .dare/config.json.example .dare/config.json
+export OPENAI_API_KEY=sk-...
+```
+
+如果你要试 OpenRouter，可以直接改用：
+
+```bash
+cp .dare/config.openrouter.example.json .dare/config.json
+export OPENROUTER_API_KEY=sk-or-...
+```
+
+### `llm` 字段说明
+
+- `adapter`：模型适配器，当前支持 `openai` 和 `openrouter`。不写时默认是 `openai`。
+- `model`：模型名，例如 `gpt-4o-mini`、`gpt-4.1`、`qwen/qwen3-coder:free`。
+- `api_key`：模型服务密钥。也可以通过环境变量提供。
+- `endpoint`：自定义 OpenAI-compatible base URL。对 `openrouter` 来说会作为 `base_url` 使用。
+- `proxy`：代理配置，支持 `http`、`https`、`no_proxy`、`use_system_proxy`、`disabled`。
+- 其他未显式声明的字段会进入 `llm.extra`，并透传给 adapter；例如可以直接写 `temperature`、`max_tokens`。
+
+### `cli` 字段说明
+
+- `cli.log_path`：CLI 日志文件路径。
+- 不配置时，默认写到当前工作目录下的 `./dare.log`。
+- 如果配置的是相对路径，也按当前工作目录解析；例如 `logs/dare.log` 会落到当前目录下的 `logs/dare.log`。
+
+示例：
+
+```json
+{
+  "cli": {
+    "log_path": "logs/dare.log"
+  }
+}
+```
+
+`proxy` 的优先级规则：
+
+- `disabled: true` 时，显式关闭代理，并忽略其他代理字段。
+- `use_system_proxy: true` 时，使用系统代理环境变量，并忽略显式 `http/https`。
+- 否则使用配置中的 `https` 或 `http`。
+
+### 常见 LLM 配置示例
+
+OpenAI：
+
+```json
+{
+  "llm": {
+    "adapter": "openai",
+    "model": "gpt-4o-mini"
+  }
+}
+```
+
+配合环境变量：
+
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+OpenRouter：
+
+```json
+{
+  "llm": {
+    "adapter": "openrouter",
+    "model": "qwen/qwen3-coder:free"
+  }
+}
+```
+
+配合环境变量：
+
+```bash
+export OPENROUTER_API_KEY=sk-or-...
+export OPENROUTER_MODEL=qwen/qwen3-coder:free
+# 可选，默认就是 https://openrouter.ai/api/v1
+export OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+```
+
+OpenAI-compatible / 自建模型网关：
+
+```json
+{
+  "llm": {
+    "adapter": "openai",
+    "model": "Qwen/Qwen2.5-Coder-32B-Instruct",
+    "endpoint": "http://127.0.0.1:8000/v1",
+    "api_key": "dummy-key"
+  }
+}
+```
+
+如果服务不校验密钥，仍建议显式给一个占位值，例如 `dummy-key`，这样 `doctor` 检查不会报 missing API key。
+
+仓库里也提供了对应的完整示例文件：
+
+- `/.dare/config.json.example`
+- `/.dare/config.openrouter.example.json`
+- `/.dare/config.advanced.example.json`
+
+对应内容如下，便于直接在 README 里参考：
+
+`/.dare/config.openrouter.example.json`
+
+```json
+{
+  "llm": {
+    "adapter": "openrouter",
+    "model": "qwen/qwen3-coder:free"
+  }
+}
+```
+
+`/.dare/config.advanced.example.json`
+
+```json
+{
+  "cli": {
+    "log_path": "logs/dare.log"
+  },
+  "llm": {
+    "adapter": "openai",
+    "model": "Qwen/Qwen2.5-Coder-32B-Instruct",
+    "endpoint": "http://127.0.0.1:8000/v1",
+    "api_key": "dummy-key",
+    "max_tokens": 4096,
+    "temperature": 0.2,
+    "proxy": {
+      "https": "http://127.0.0.1:7890",
+      "no_proxy": "127.0.0.1,localhost"
+    }
+  }
+}
+```
+
+### 临时覆盖配置
+
+临时切模型或切换 provider 时，可以直接用 CLI flags 覆盖文件配置：
+
+```bash
+.venv/bin/python -m client \
+  --adapter openrouter \
+  --model qwen/qwen3-coder:free \
+  --api-key "$OPENROUTER_API_KEY" \
+  chat
+```
+
+或者只临时改 endpoint：
+
+```bash
+.venv/bin/python -m client \
+  --endpoint http://127.0.0.1:8000/v1 \
+  run --task "读取 README 并总结"
+```
+
+### 如何确认配置是否生效
+
+建议按下面顺序检查：
+
+```bash
+# 查看最终生效的合并配置
+.venv/bin/python -m client config show
+
+# 查看当前 runtime 选中的模型信息
+.venv/bin/python -m client model show
+
+# 做环境与依赖诊断
+.venv/bin/python -m client doctor
+```
+
+这三个命令分别用于：
+
+- `config show`：确认 `llm`、`mcp_paths`、`allow_tools` 等最终生效值。
+- `model show`：确认 runtime 实际加载的 adapter 名称和 model 名称。
+- `doctor`：检查配置文件是否存在、API key 是否可见、adapter 依赖是否安装、MCP 路径是否有效。
+
+### LLM 相关依赖
+
+如果你是用 `pip install -e . --no-deps` 只安装 CLI 入口，还需要自行安装模型适配器依赖：
+
+- `openai` adapter：需要 `langchain-openai`
+- `openrouter` adapter：需要 `openai`
+
+否则 `doctor` 会提示 adapter probe 或依赖缺失，runtime 也无法正常启动。
+
 ## 输出与退出码
 
-- `--output human`：人类可读日志（默认）
+- `--output human`：终端只显示用户交互内容；CLI 日志写入 `cli.log_path` 指定文件，默认 `./dare.log`
 - `--output json`：结构化行输出，适合脚本集成
+
+`human` 模式下常见行为：
+
+- 启动信息、运行时状态、自动审批等日志不再打印到终端，会进入日志文件。
+- 任务结果、plan preview、显式命令输出、需要用户处理的错误/审批提示仍会显示在终端。
+- `chat` 模式下，发送消息后如果任务还没完成，CLI 不会立刻再次显示 `dare>` 提示；等回复完成后才会回到下一次输入。
+- `chat` + `human` 模式下，如果运行过程中出现工具审批，CLI 会直接在终端内联显示审批内容，包括原因、命令和工作目录，并给出三种选择：
+  `1` 或 `y/yes` 表示仅允许这一次，
+  `2` 表示当前会话内对这条相同命令自动允许，
+  `3`、`n/no` 或直接回车表示拒绝；不需要再手动敲 `/approvals grant|deny`。
+- `--output json` 或显式 `approvals` 子命令仍保留 transport/action 控制面，适合脚本、外部 UI 或调试场景。
+- 如果需要保留结构化 stdout 给脚本消费，使用 `--output json`。
 
 JSON 行结构（简化）：
 

--- a/client/main.py
+++ b/client/main.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 import dataclasses
 import json
+import logging
 import time
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterable
@@ -26,6 +27,7 @@ from client.render.json import JsonRenderer
 from client.runtime.action_client import ActionClientError, TransportActionClient
 from client.runtime.bootstrap import RuntimeOptions, bootstrap_runtime, load_effective_config
 from client.runtime.event_stream import EventPump
+from client.runtime.logging_setup import CLI_LOGGER_NAME, configure_cli_logging, resolve_cli_log_path
 from client.runtime.task_runner import format_run_output, preview_plan, run_task
 from client.session import CLISessionState, ExecutionMode, SessionStatus
 from dare_framework.model.default_model_adapter_manager import DefaultModelAdapterManager
@@ -39,48 +41,65 @@ class OutputFacade:
         self._mode = mode
         self._human = HumanRenderer() if mode == "human" else None
         self._json = JsonRenderer() if mode == "json" else None
+        self._logger = logging.getLogger(CLI_LOGGER_NAME)
 
     @property
     def mode(self) -> str:
         return self._mode
 
     def header(self, title: str) -> None:
+        self._logger.info("%s", title)
         if self._human is not None:
-            self._human.header(title)
             return
         self._json.emit({"type": "event", "event": "header", "data": {"title": title}})
 
     def info(self, text: str) -> None:
+        self._logger.info("%s", text)
         if self._human is not None:
-            self._human.info(text)
             return
         self._json.emit({"type": "log", "level": "info", "message": text})
 
     def warn(self, text: str) -> None:
+        self._logger.warning("%s", text)
         if self._human is not None:
-            self._human.warn(text)
             return
         self._json.emit({"type": "log", "level": "warn", "message": text})
 
     def ok(self, text: str) -> None:
+        self._logger.info("%s", text)
         if self._human is not None:
-            self._human.ok(text)
             return
         self._json.emit({"type": "log", "level": "ok", "message": text})
 
     def error(self, text: str) -> None:
+        self._logger.error("%s", text)
         if self._human is not None:
-            self._human.error(text)
             return
         self._json.emit({"type": "log", "level": "error", "message": text})
 
-    def show_mode(self, mode: ExecutionMode) -> None:
+    def display(self, text: str, *, level: str = "info") -> None:
+        level_name = level.strip().lower()
+        if level_name == "warn":
+            self.warn(text)
+        elif level_name == "error":
+            self.error(text)
+        elif level_name == "ok":
+            self.ok(text)
+        else:
+            self.info(text)
+
         if self._human is not None:
-            self._human.show_mode(mode)
+            self._human.message(text)
+
+    def show_mode(self, mode: ExecutionMode) -> None:
+        self._logger.info("mode=%s", mode.value)
+        if self._human is not None:
+            self._human.message(f"mode={mode.value}")
             return
         self._json.emit({"type": "event", "event": "mode", "data": {"mode": mode.value}})
 
     def show_plan(self, plan: Any) -> None:
+        self._logger.info("plan preview: %s", getattr(plan, "plan_description", ""))
         if self._human is not None:
             self._human.show_plan(plan)
             return
@@ -98,14 +117,15 @@ class OutputFacade:
         self._json.emit({"type": "event", "event": "plan_preview", "data": payload})
 
     def emit_data(self, payload: Any) -> None:
+        self._logger.info("result=%s", json.dumps(_serialize(payload), ensure_ascii=False))
         if self._human is not None:
             print(json.dumps(payload, ensure_ascii=False, indent=2), flush=True)
             return
         self._json.emit({"type": "result", "data": payload})
 
     def emit_event(self, event: str, payload: Any) -> None:
+        self._logger.info("event=%s payload=%s", event, json.dumps(_serialize(payload), ensure_ascii=False))
         if self._human is not None:
-            print(json.dumps({"event": event, "payload": payload}, ensure_ascii=False), flush=True)
             return
         self._json.emit({"type": "event", "event": event, "data": payload})
 
@@ -138,7 +158,7 @@ def _load_script_lines_with_handling(path: Path, *, output: OutputFacade) -> lis
     try:
         return _load_script_lines(path)
     except OSError as exc:
-        output.error(f"failed to load script file: {exc}")
+        output.display(f"failed to load script file: {exc}", level="error")
         return None
 
 
@@ -164,27 +184,29 @@ async def _execute_task_and_report(
     except asyncio.CancelledError:
         state.last_execution_success = False
         state.execution_failures += 1
-        output.warn("execution cancelled")
+        output.display("execution cancelled", level="warn")
         return False
     except Exception as exc:  # noqa: BLE001
         state.last_execution_success = False
         state.execution_failures += 1
-        output.error(f"execution error: {exc}")
+        output.display(f"execution error: {exc}", level="error")
         return False
 
     if result.success:
         state.last_execution_success = True
-        output.ok("task completed")
         text = format_run_output(result.output)
         if text:
-            output.info(text)
+            output.display(text)
+        else:
+            output.display("task completed", level="ok")
+        output.ok("task completed")
         return True
 
     state.last_execution_success = False
     state.execution_failures += 1
-    output.error("task failed")
+    output.display("task failed", level="error")
     if result.errors:
-        output.error(f"errors: {result.errors}")
+        output.display(f"errors: {result.errors}", level="error")
     return False
 
 
@@ -199,12 +221,13 @@ async def _finalize_background_task_if_done(
     try:
         await task
     except asyncio.CancelledError:
-        output.warn("execution cancelled")
+        output.display("execution cancelled", level="warn")
     except Exception as exc:  # noqa: BLE001
-        output.error(f"execution failed: {exc}")
+        output.display(f"execution failed: {exc}", level="error")
     finally:
         state.active_execution_task = None
         state.active_execution_description = None
+        state.clear_runtime_approvals()
         if state.status == SessionStatus.RUNNING:
             state.status = SessionStatus.IDLE
 
@@ -224,6 +247,22 @@ async def _wait_for_background_task(
             pass
         except Exception:
             pass
+    await _finalize_background_task_if_done(state, output=output)
+
+
+async def _wait_until_prompt_allowed(
+    state: CLISessionState,
+    *,
+    output: OutputFacade,
+    release_on_pending: bool = True,
+    poll_interval_seconds: float = 0.05,
+) -> None:
+    """Hold the prompt while a task is running unless user action is required."""
+    while _is_execution_running(state):
+        if release_on_pending and state.has_pending_runtime_approval():
+            return
+        await asyncio.sleep(poll_interval_seconds)
+        await _finalize_background_task_if_done(state, output=output)
     await _finalize_background_task_if_done(state, output=output)
 
 
@@ -261,9 +300,112 @@ DEFAULT_AUTO_APPROVE_TOOLS: frozenset[str] = frozenset(
         # Keep this set aligned with currently registered runtime tool names.
         "read_file",
         "search_code",
-        "write_file",
     }
 )
+
+
+def _approval_request_lines(
+    *,
+    request: dict[str, Any],
+    tool_name: str,
+    capability_id: str,
+) -> list[str]:
+    """Render the approval request so the user can see exactly what is being allowed."""
+    params = request.get("params", {})
+    command = request.get("command")
+    reason = request.get("reason")
+    cwd = params.get("cwd") if isinstance(params, dict) else None
+
+    if capability_id == "run_command" or tool_name == "run_command":
+        lines = ["Agent wants to run a shell command."]
+    else:
+        label = tool_name or capability_id or "Tool"
+        lines = [f"{label} requires approval."]
+
+    if isinstance(reason, str) and reason.strip():
+        lines.append(f"Reason: {reason.strip()}")
+    if isinstance(command, str) and command.strip():
+        lines.append(f"Command: {command.strip()}")
+    if isinstance(cwd, str) and cwd.strip():
+        lines.append(f"Cwd: {cwd.strip()}")
+    has_command = isinstance(command, str) and bool(command.strip())
+    if not has_command and isinstance(params, dict) and params:
+        lines.append(f"Params: {json.dumps(_serialize(params), ensure_ascii=False, sort_keys=True)}")
+
+    lines.extend(
+        [
+            "Choose what to do:",
+            "1. Allow once",
+            "2. Always allow this exact command in this session",
+            "3. Deny (default)",
+        ]
+    )
+    return lines
+
+
+def _parse_inline_approval_choice(raw: str) -> tuple[ResourceAction, str, str] | None:
+    """Interpret interactive approval input."""
+    answer = raw.strip().lower()
+    if answer in {"1", "y", "yes"}:
+        return ResourceAction.APPROVALS_GRANT, "once", "exact_params"
+    if answer in {"2", "a", "always", "session"}:
+        return ResourceAction.APPROVALS_GRANT, "session", "exact_params"
+    if answer in {"", "3", "n", "no"}:
+        return ResourceAction.APPROVALS_DENY, "once", "exact_params"
+    return None
+
+
+async def _resolve_inline_chat_approval(
+    *,
+    action_client: TransportActionClient,
+    output: OutputFacade,
+    request: dict[str, Any],
+    tool_name: str,
+    capability_id: str,
+) -> None:
+    """Collect an inline approval decision for human chat sessions."""
+    normalized_request = str(request.get("request_id", "?")).strip() or "?"
+    for line in _approval_request_lines(
+        request=request,
+        tool_name=tool_name.strip(),
+        capability_id=capability_id.strip(),
+    ):
+        output.display(line, level="warn")
+
+    while True:
+        try:
+            raw = await asyncio.to_thread(input, "approve> ")
+        except (EOFError, KeyboardInterrupt):
+            raw = ""
+        parsed = _parse_inline_approval_choice(raw)
+
+        if parsed is None:
+            output.display("Choose 1, 2, or 3.", level="warn")
+            continue
+        action, scope, matcher = parsed
+        decision = "allow" if action == ResourceAction.APPROVALS_GRANT else "deny"
+
+        try:
+            await action_client.invoke_action(
+                action,
+                request_id=normalized_request,
+                scope=scope,
+                matcher=matcher,
+            )
+        except Exception as exc:  # noqa: BLE001
+            output.display(f"failed to submit approval decision: {exc}", level="error")
+            continue
+
+        if action == ResourceAction.APPROVALS_GRANT and scope == "session":
+            output.display(
+                "Same command will be auto-approved for the rest of this session.",
+                level="ok",
+            )
+        output.info(
+            "approval decision submitted: "
+            f"request_id={normalized_request}, decision={decision}, scope={scope}, matcher={matcher}"
+        )
+        return
 
 
 @dataclasses.dataclass
@@ -288,13 +430,15 @@ class _RunApprovalPolicy:
             if normalized_request in self.seen_disallowed:
                 return
             self.seen_disallowed.add(normalized_request)
-            self.output.warn(
+            self.output.display(
                 "auto-approve skipped: "
-                f"request_id={normalized_request}, tool={normalized_tool}, capability={capability_id}"
+                f"request_id={normalized_request}, tool={normalized_tool}, capability={capability_id}",
+                level="warn",
             )
-            self.output.warn(
+            self.output.display(
                 "rerun with `--auto-approve-tool "
-                f"{normalized_tool}` to allow this tool in run mode"
+                f"{normalized_tool}` to allow this tool in run mode",
+                level="warn",
             )
             return
 
@@ -312,8 +456,10 @@ class _RunApprovalPolicy:
                 matcher="exact_params",
             )
         except Exception as exc:  # noqa: BLE001
-            self.output.error(
+            self.output.display(
                 f"auto-approve failed for request_id={normalized_request}: {exc}"
+                ,
+                level="error",
             )
             return
         self.output.ok(f"auto-approved request_id={normalized_request}")
@@ -349,13 +495,15 @@ async def _execute_task_with_approval_timeout(
                 elapsed = time.monotonic() - approval_watch.pending_since_monotonic
                 if elapsed >= approval_timeout_seconds:
                     request_id = approval_watch.request_id or "?"
-                    output.error(
+                    output.display(
                         "approval wait timed out "
-                        f"(request_id={request_id}, timeout={approval_timeout_seconds:.1f}s)"
+                        f"(request_id={request_id}, timeout={approval_timeout_seconds:.1f}s)",
+                        level="error",
                     )
-                    output.error(
+                    output.display(
                         "rerun with `--auto-approve-tool <tool_name>` "
-                        "or use `chat` mode to approve manually"
+                        "or use `chat` mode to approve manually",
+                        level="error",
                     )
                     task.cancel()
                     break
@@ -385,15 +533,15 @@ async def _handle_shell_command(
 ) -> bool:
     if command.type == CommandType.QUIT:
         if _is_execution_running(state):
-            output.warn("cancelling running execution")
+            output.display("cancelling running execution", level="warn")
             assert state.active_execution_task is not None
             state.active_execution_task.cancel()
             await _finalize_background_task_if_done(state, output=output)
-        output.info("bye")
+        output.display("bye")
         return True
 
     if command.type == CommandType.HELP:
-        output.info(
+        output.display(
             "/mode [plan|execute], /approve, /reject, /status, "
             "/approvals [...], /mcp [...], /tools list, /skills list, "
             "/config show, /model show, /interrupt, /quit"
@@ -402,18 +550,18 @@ async def _handle_shell_command(
 
     if command.type == CommandType.STATUS:
         running = _is_execution_running(state)
-        output.info(f"status={state.status.value}, mode={state.mode.value}, running={running}")
+        output.display(f"status={state.status.value}, mode={state.mode.value}, running={running}")
         if running and state.active_execution_description:
-            output.info(f"active_task={state.active_execution_description}")
+            output.display(f"active_task={state.active_execution_description}")
         return False
 
     if command.type == CommandType.MODE:
         if not command.args:
-            output.warn("/mode requires plan or execute")
+            output.display("/mode requires plan or execute", level="warn")
             return False
         mode = command.args[0].strip().lower()
         if mode not in {"plan", "execute"}:
-            output.warn(f"unknown mode: {mode}")
+            output.display(f"unknown mode: {mode}", level="warn")
             return False
         state.mode = _normalize_mode(mode)
         output.show_mode(state.mode)
@@ -421,11 +569,11 @@ async def _handle_shell_command(
 
     if command.type == CommandType.APPROVE:
         if state.pending_task_description is None:
-            output.warn("no pending plan")
+            output.display("no pending plan", level="warn")
             return False
         task_text = state.pending_task_description
         if background_execute and _is_execution_running(state):
-            output.warn("another execution is running")
+            output.display("another execution is running", level="warn")
             return False
         state.clear_pending()
         if background_execute:
@@ -456,16 +604,16 @@ async def _handle_shell_command(
         state.clear_pending()
         if not _is_execution_running(state):
             state.status = SessionStatus.IDLE
-        output.info("plan rejected")
+        output.display("plan rejected")
         return False
 
     if command.type == CommandType.APPROVALS:
         try:
             payload = await handle_approvals_tokens(command.args, action_client=action_client)
         except Exception as exc:  # noqa: BLE001
-            output.error(str(exc))
+            output.display(str(exc), level="error")
             for line in approvals_usage_lines():
-                output.info(line)
+                output.display(line)
             return False
         output.emit_data(_serialize(payload))
         return False
@@ -474,11 +622,11 @@ async def _handle_shell_command(
         try:
             payload = await handle_mcp_tokens(command.args, runtime=runtime)
         except Exception as exc:  # noqa: BLE001
-            output.error(str(exc))
-            output.info("/mcp list|inspect [tool_name]|reload [paths...]|unload")
+            output.display(str(exc), level="error")
+            output.display("/mcp list|inspect [tool_name]|reload [paths...]|unload")
             return False
         if "tools" in payload:
-            output.info(format_mcp_inspection(payload["tools"]))
+            output.display(format_mcp_inspection(payload["tools"]))
         else:
             output.emit_data(_serialize(payload))
         return False
@@ -544,13 +692,13 @@ async def _run_cli_loop(
                 # Command failures must affect scripted exit status.
                 state.last_execution_success = False
                 state.execution_failures += 1
-                output.error(str(exc))
+                output.display(str(exc), level="error")
                 continue
             except Exception as exc:  # noqa: BLE001
                 # Keep command exceptions visible while preserving deterministic script rc.
                 state.last_execution_success = False
                 state.execution_failures += 1
-                output.error(f"command failed: {exc}")
+                output.display(f"command failed: {exc}", level="error")
                 continue
             if quit_requested:
                 break
@@ -574,16 +722,16 @@ async def _run_cli_loop(
                 # Plan preview failures should affect scripted exit status.
                 state.last_execution_success = False
                 state.execution_failures += 1
-                output.error(f"plan preview failed: {exc}")
+                output.display(f"plan preview failed: {exc}", level="error")
                 continue
             state.status = SessionStatus.AWAITING_APPROVAL
             output.show_plan(state.pending_plan)
-            output.info("type /approve to execute or /reject to cancel")
+            output.display("type /approve to execute or /reject to cancel")
             continue
 
         if background_execute:
             if _is_execution_running(state):
-                output.warn("another execution is running")
+                output.display("another execution is running", level="warn")
                 continue
             state.status = SessionStatus.RUNNING
             state.active_execution_description = task_text
@@ -615,14 +763,16 @@ def _on_transport_event(
     payload: dict[str, Any],
     *,
     output: OutputFacade,
-    on_approval_pending: Callable[[str, str, str], Awaitable[None] | None] | None = None,
+    on_approval_pending: Callable[[dict[str, Any], str, str], Awaitable[None] | None] | None = None,
     on_approval_resolved: Callable[[str], Awaitable[None] | None] | None = None,
+    suppress_human_approval_pending_output: bool = False,
 ) -> Awaitable[None] | None:
     return _on_transport_event_async(
         payload,
         output=output,
         on_approval_pending=on_approval_pending,
         on_approval_resolved=on_approval_resolved,
+        suppress_human_approval_pending_output=suppress_human_approval_pending_output,
     )
 
 
@@ -630,8 +780,9 @@ async def _on_transport_event_async(
     payload: dict[str, Any],
     *,
     output: OutputFacade,
-    on_approval_pending: Callable[[str, str, str], Awaitable[None] | None] | None = None,
+    on_approval_pending: Callable[[dict[str, Any], str, str], Awaitable[None] | None] | None = None,
     on_approval_resolved: Callable[[str], Awaitable[None] | None] | None = None,
+    suppress_human_approval_pending_output: bool = False,
 ) -> None:
     payload_type = payload.get("type")
     if payload_type == "approval_pending":
@@ -641,10 +792,14 @@ async def _on_transport_event_async(
         capability_id = str(resp.get("capability_id", "?")) if isinstance(resp, dict) else "?"
         tool_name = str(resp.get("tool_name", "?")) if isinstance(resp, dict) else "?"
         if on_approval_pending is not None:
-            maybe_awaitable = on_approval_pending(request_id, tool_name, capability_id)
+            maybe_awaitable = on_approval_pending(request, tool_name, capability_id)
             if maybe_awaitable is not None:
                 await maybe_awaitable
-        output.warn(f"approval pending: request_id={request_id}, capability={capability_id}")
+        message = f"approval pending: request_id={request_id}, capability={capability_id}"
+        if suppress_human_approval_pending_output and output.mode == "human":
+            output.warn(message)
+        else:
+            output.display(message, level="warn")
         return
     if payload_type == "approval_resolved":
         resp = payload.get("resp", {})
@@ -673,10 +828,31 @@ async def _run_chat(
     script_lines: list[str] | None,
 ) -> int:
     state = CLISessionState(mode=_normalize_mode(mode))
-    output.show_mode(state.mode)
+    inline_chat_approvals = script_lines is None and output.mode == "human"
+
+    async def _handle_chat_approval_pending(request: dict[str, Any], tool_name: str, capability_id: str) -> None:
+        request_id = str(request.get("request_id", "?")).strip() or "?"
+        state.mark_runtime_approval_pending(request_id)
+        if not inline_chat_approvals:
+            return
+        await _resolve_inline_chat_approval(
+            action_client=action_client,
+            output=output,
+            request=request,
+            tool_name=tool_name,
+            capability_id=capability_id,
+        )
+
+    output.info(f"mode={state.mode.value}")
     pump = EventPump(
         client_channel=runtime.client_channel,
-        on_event=lambda payload: _on_transport_event(payload, output=output),
+        on_event=lambda payload: _on_transport_event(
+            payload,
+            output=output,
+            on_approval_pending=_handle_chat_approval_pending,
+            on_approval_resolved=state.mark_runtime_approval_resolved,
+            suppress_human_approval_pending_output=inline_chat_approvals,
+        ),
     )
     pump.start()
     try:
@@ -692,11 +868,11 @@ async def _run_chat(
                 background_execute=False,
             )
             if _is_execution_running(state):
-                output.warn("waiting for last background execution")
+                output.display("waiting for last background execution", level="warn")
                 await _wait_for_background_task(state, output=output)
             return 0 if state.execution_failures == 0 else 1
 
-        output.info("type /help for commands. /quit to exit.")
+        output.display("type /help for commands. /quit to exit.")
         while True:
             try:
                 # Offload blocking stdin reads so background tasks/event pump keep running.
@@ -717,8 +893,13 @@ async def _run_chat(
             )
             if quit_requested:
                 break
+            await _wait_until_prompt_allowed(
+                state,
+                output=output,
+                release_on_pending=not inline_chat_approvals,
+            )
         if _is_execution_running(state):
-            output.warn("waiting for running execution")
+            output.display("waiting for running execution", level="warn")
             await _wait_for_background_task(state, output=output)
         return 0
     finally:
@@ -842,11 +1023,12 @@ def _build_runtime_options(args: argparse.Namespace) -> RuntimeOptions:
 async def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
+    configure_cli_logging(resolve_cli_log_path())
     output = OutputFacade(args.output)
     try:
         options = _build_runtime_options(args)
     except OSError as exc:
-        output.error(f"invalid runtime path: {exc}")
+        output.display(f"invalid runtime path: {exc}", level="error")
         return 2
     runtime = None
     exit_code = 0
@@ -855,9 +1037,10 @@ async def main(argv: list[str] | None = None) -> int:
         try:
             provider, config = load_effective_config(options)
         except (OSError, ValueError) as exc:
-            output.error(f"invalid config: {exc}")
+            output.display(f"invalid config: {exc}", level="error")
             return 2
         _ = provider
+        configure_cli_logging(resolve_cli_log_path(config))
 
         output.header("DARE CLIENT CLI")
         output.info(f"workspace={config.workspace_dir}")
@@ -881,7 +1064,7 @@ async def main(argv: list[str] | None = None) -> int:
         try:
             runtime = await bootstrap_runtime(options)
         except Exception as exc:  # noqa: BLE001
-            output.error(f"runtime bootstrap failed: {exc}")
+            output.display(f"runtime bootstrap failed: {exc}", level="error")
             return 1
         action_client = TransportActionClient(runtime.client_channel, timeout_seconds=args.timeout)
 
@@ -910,11 +1093,11 @@ async def main(argv: list[str] | None = None) -> int:
                         user_dir=runtime.config.user_dir,
                     )
                 except Exception as exc:  # noqa: BLE001
-                    output.error(f"plan preview failed: {exc}")
+                    output.display(f"plan preview failed: {exc}", level="error")
                     return 1
                 output.show_plan(plan)
                 if not args.approve:
-                    output.info("plan only (pass --approve to execute)")
+                    output.display("plan only (pass --approve to execute)")
                     return 0
             auto_tools: set[str] = set()
             if args.auto_approve:
@@ -939,7 +1122,11 @@ async def main(argv: list[str] | None = None) -> int:
                 on_event=lambda payload: _on_transport_event(
                     payload,
                     output=output,
-                    on_approval_pending=approval_policy.on_pending,
+                    on_approval_pending=lambda request, tool_name, capability_id: approval_policy.on_pending(
+                        str(request.get("request_id", "?")).strip() or "?",
+                        tool_name,
+                        capability_id,
+                    ),
                     on_approval_resolved=approval_watch.mark_resolved,
                 ),
             )
@@ -998,11 +1185,11 @@ async def main(argv: list[str] | None = None) -> int:
             try:
                 payload = await handle_mcp_tokens(tokens, runtime=runtime)
             except Exception as exc:  # noqa: BLE001
-                output.error(str(exc))
-                output.info("/mcp list|inspect [tool_name]|reload [paths...]|unload")
+                output.display(str(exc), level="error")
+                output.display("/mcp list|inspect [tool_name]|reload [paths...]|unload")
                 return 1
             if "tools" in payload:
-                output.info(format_mcp_inspection(payload["tools"]))
+                output.display(format_mcp_inspection(payload["tools"]))
             else:
                 output.emit_data(_serialize(payload))
             return 0
@@ -1032,13 +1219,13 @@ async def main(argv: list[str] | None = None) -> int:
             output.emit_data(_serialize(payload))
             return 0
 
-        output.error(f"unknown command: {command}")
+        output.display(f"unknown command: {command}", level="error")
         exit_code = 2
     except ActionClientError as exc:
-        output.error(str(exc))
+        output.display(str(exc), level="error")
         exit_code = 1
     except KeyboardInterrupt:
-        output.warn("interrupted")
+        output.display("interrupted", level="warn")
         exit_code = 130
     finally:
         if runtime is not None:

--- a/client/render/human.py
+++ b/client/render/human.py
@@ -17,6 +17,9 @@ class HumanRenderer:
         rule = "=" * self._width
         print(f"\n{rule}\n{title}\n{rule}\n", flush=True)
 
+    def message(self, text: str) -> None:
+        print(text, flush=True)
+
     def info(self, text: str) -> None:
         print(f"[INFO] {text}", flush=True)
 

--- a/client/runtime/logging_setup.py
+++ b/client/runtime/logging_setup.py
@@ -1,0 +1,52 @@
+"""CLI file logging helpers."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from dare_framework.config import Config
+
+DEFAULT_CLI_LOG_FILENAME = "dare.log"
+CLI_LOGGER_NAME = "dare.client.cli"
+
+
+def resolve_cli_log_path(config: Config | None = None, *, cwd: Path | None = None) -> Path:
+    """Resolve the CLI log path from config or fall back to ``./dare.log``."""
+    base_dir = (cwd or Path.cwd()).expanduser().resolve()
+    raw_path = config.cli.log_path if config is not None else None
+    if raw_path is None or not raw_path.strip():
+        return base_dir / DEFAULT_CLI_LOG_FILENAME
+
+    path = Path(raw_path.strip()).expanduser()
+    if not path.is_absolute():
+        path = (base_dir / path).resolve()
+    return path
+
+
+def configure_cli_logging(log_path: Path, *, level: int = logging.INFO) -> Path:
+    """Send Python logging output to a single file and nowhere else."""
+    resolved = log_path.expanduser().resolve()
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+        handler.close()
+
+    file_handler = logging.FileHandler(resolved, encoding="utf-8", delay=True)
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+    )
+    root.addHandler(file_handler)
+    root.setLevel(level)
+    logging.captureWarnings(True)
+    return resolved
+
+
+__all__ = [
+    "CLI_LOGGER_NAME",
+    "DEFAULT_CLI_LOG_FILENAME",
+    "configure_cli_logging",
+    "resolve_cli_log_path",
+]

--- a/client/session.py
+++ b/client/session.py
@@ -37,8 +37,30 @@ class CLISessionState:
     conversation_id: str = field(default_factory=lambda: uuid4().hex)
     execution_failures: int = 0
     last_execution_success: bool | None = None
+    pending_runtime_approvals: set[str] = field(default_factory=set)
 
     def clear_pending(self) -> None:
         """Drop in-memory plan preview state."""
         self.pending_plan = None
         self.pending_task_description = None
+
+    def mark_runtime_approval_pending(self, request_id: str) -> None:
+        """Track a transport approval that needs user action."""
+        normalized = request_id.strip() or "?"
+        self.pending_runtime_approvals.add(normalized)
+
+    def mark_runtime_approval_resolved(self, request_id: str) -> None:
+        """Clear a tracked runtime approval once transport reports resolution."""
+        normalized = request_id.strip() or "?"
+        if normalized == "?":
+            self.pending_runtime_approvals.clear()
+            return
+        self.pending_runtime_approvals.discard(normalized)
+
+    def has_pending_runtime_approval(self) -> bool:
+        """Return True when the running task is blocked on user approval."""
+        return bool(self.pending_runtime_approvals)
+
+    def clear_runtime_approvals(self) -> None:
+        """Clear approval state when execution ends or resets."""
+        self.pending_runtime_approvals.clear()

--- a/dare_framework/config/__init__.py
+++ b/dare_framework/config/__init__.py
@@ -6,6 +6,7 @@ from dare_framework.config.kernel import IConfigProvider
 from dare_framework.config.factory import build_config_provider
 from dare_framework.config.file_config_provider import FileConfigProvider
 from dare_framework.config.types import (
+    CLIConfig,
     ComponentConfig,
     Config,
     LLMConfig,
@@ -15,6 +16,7 @@ from dare_framework.config.types import (
 )
 
 __all__ = [
+    "CLIConfig",
     "ComponentConfig",
     "Config",
     "IConfigProvider",

--- a/dare_framework/config/_internal/action_handler.py
+++ b/dare_framework/config/_internal/action_handler.py
@@ -47,6 +47,7 @@ class ConfigActionHandler(IActionHandler):
             "workspace_dir": data.get("workspace_dir"),
             "user_dir": data.get("user_dir"),
             "llm": data.get("llm"),
+            "cli": data.get("cli"),
             "allow_tools": data.get("allow_tools"),
             "allow_mcps": data.get("allow_mcps"),
             "mcp_paths": data.get("mcp_paths"),

--- a/dare_framework/config/types.py
+++ b/dare_framework/config/types.py
@@ -269,6 +269,25 @@ class ObservabilityConfig:
 
 
 @dataclass(frozen=True)
+class CLIConfig:
+    """CLI-specific runtime behavior."""
+
+    log_path: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CLIConfig:
+        raw_log_path = data.get("log_path")
+        log_path = str(raw_log_path) if raw_log_path is not None else None
+        return cls(log_path=log_path)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        if self.log_path is not None:
+            payload["log_path"] = self.log_path
+        return payload
+
+
+@dataclass(frozen=True)
 class HooksConfig:
     """Governance configuration for runtime hook orchestration."""
 
@@ -332,6 +351,7 @@ class Config:
     skill_paths: list[str] = field(default_factory=list)
     """Directories to scan for skills (SKILL.md). When non-empty, used by SkillStoreBuilder; else default .dare/skills."""
     tools: dict[str, dict[str, Any]] = field(default_factory=dict)
+    cli: CLIConfig = field(default_factory=CLIConfig)
     allow_tools: list[str] = field(default_factory=list)
     allow_mcps: list[str] = field(default_factory=list)
     components: dict[str, ComponentConfig] = field(default_factory=dict)
@@ -365,6 +385,8 @@ class Config:
             else []
         )
         tools = data.get("tools") if isinstance(data.get("tools"), dict) else {}
+        cli_raw = data.get("cli")
+        cli = CLIConfig.from_dict(cli_raw) if isinstance(cli_raw, dict) else CLIConfig()
         allow_tools = [str(item) for item in data.get("allow_tools", [])] if isinstance(data.get("allow_tools"), list) else []
         allow_mcps = [str(item) for item in data.get("allow_mcps", [])] if isinstance(data.get("allow_mcps"), list) else []
         components_raw = data.get("components") if isinstance(data.get("components"), dict) else {}
@@ -406,6 +428,7 @@ class Config:
             mcp_paths=mcp_paths,
             skill_paths=skill_paths,
             tools=tools,
+            cli=cli,
             allow_tools=allow_tools,
             allow_mcps=allow_mcps,
             components=components,
@@ -456,6 +479,7 @@ class Config:
             "mcp_paths": list(self.mcp_paths),
             "skill_paths": list(self.skill_paths),
             "tools": dict(self.tools),
+            "cli": self.cli.to_dict(),
             "allow_tools": list(self.allow_tools),
             "allow_mcps": list(self.allow_mcps),
             "components": {key: value.to_dict() for key, value in self.components.items()},
@@ -469,6 +493,7 @@ class Config:
             "observability": self.observability.to_dict(),
         }
 __all__ = [
+    "CLIConfig",
     "ProxyConfig",
     "LLMConfig",
     "ComponentConfig",

--- a/dare_framework/tool/_internal/tools/write_file.py
+++ b/dare_framework/tool/_internal/tools/write_file.py
@@ -58,7 +58,7 @@ class WriteFileTool(ITool):
 
     @property
     def requires_approval(self) -> bool:
-        return False
+        return True
 
     @property
     def timeout_seconds(self) -> int:

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,13 @@
    ├── /examples/07-tool-approval-memory/ (工具审批记忆与自动放行示例)
    └── /examples/08-hook-governance/ (Hook 治理：patch + block 示例)
 
-7. 开发规范
+7. CLI 使用与配置
+   ├── /client/README.md (命令入口、`.dare/config.json`、LLM 配置说明)
+   ├── /.dare/config.json.example (OpenAI 最小配置)
+   ├── /.dare/config.openrouter.example.json (OpenRouter 最小配置)
+   └── /.dare/config.advanced.example.json (进阶配置示例)
+
+8. 开发规范
    ├── /CONTRIBUTING_AI.md (AI Agent 协作规范)
    └── guides/Development_Constraints.md (开发约束清单)
 ```
@@ -66,6 +72,10 @@
 | 文档/目录 | 作用 | 状态 |
 |---|---|---|
 | `dare_framework/` | 框架实现主目录（目标收敛到单一架构；详见权威设计） | ✅ 实现入口 |
+| `client/README.md` | DARE Client CLI 用法与配置入口，含 `.dare/config.json` 和 LLM 配置说明 | ✅ CLI 入口 |
+| `.dare/config.json.example` | OpenAI 最小配置示例，可作为 workspace `.dare/config.json` 起点 | ✅ 配置示例 |
+| `.dare/config.openrouter.example.json` | OpenRouter 最小配置示例 | ✅ 配置示例 |
+| `.dare/config.advanced.example.json` | 含 `endpoint/proxy/max_tokens` 的进阶配置示例 | ✅ 配置示例 |
 | `Project_Architecture_and_Priorities.md` | 以“实现视角”梳理现状与优先级（阅读入口指向权威设计） | ✅ 实现视角 |
 | `todos/README.md` | TODO 目录维护规则与生命周期说明 | ✅ 全局规划 |
 | `todos/project_overall_todos.md` | 项目总体 TODO 清单（跨模块路线图） | ✅ 全局规划 |
@@ -285,5 +295,5 @@ docs/
 
 ---
 
-*最后更新：2026-01-22*  
+*最后更新：2026-02-27*
 *维护者：DARE Framework Team*

--- a/tests/integration/test_client_cli_flow.py
+++ b/tests/integration/test_client_cli_flow.py
@@ -117,6 +117,105 @@ async def test_main_script_returns_nonzero_when_execution_fails(monkeypatch: pyt
 
 
 @pytest.mark.asyncio
+async def test_main_run_human_logs_to_default_file_and_keeps_stdout_to_task_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    client_main = importlib.import_module("client.main")
+    config = _config_for_tests(tmp_path)
+    runtime = _FakeRuntime(config=config)
+
+    def _fake_load_effective_config(_options):  # noqa: ANN001
+        return object(), config
+
+    async def _fake_bootstrap_runtime(_options):  # noqa: ANN001
+        return runtime
+
+    class _OkResult:
+        success = True
+        output = {"content": "assistant says hi"}
+        errors: list[str] = []
+
+    async def _fake_run_task(*, agent, task_text, conversation_id=None, transport=None):  # noqa: ANN001
+        _ = (agent, task_text, conversation_id, transport)
+        return _OkResult()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(client_main, "load_effective_config", _fake_load_effective_config)
+    monkeypatch.setattr(client_main, "bootstrap_runtime", _fake_bootstrap_runtime)
+    monkeypatch.setattr(client_main, "run_task", _fake_run_task)
+
+    rc = await client_main.main(
+        [
+            "--workspace",
+            config.workspace_dir,
+            "--user-dir",
+            config.user_dir,
+            "run",
+            "--task",
+            "do one task",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    log_path = tmp_path / "dare.log"
+
+    assert rc == 0
+    assert output.strip() == "assistant says hi"
+    assert log_path.exists()
+    log_text = log_path.read_text(encoding="utf-8")
+    assert "workspace=" in log_text
+    assert "task completed" in log_text
+    assert runtime.closed is True
+
+
+@pytest.mark.asyncio
+async def test_main_doctor_human_uses_configured_log_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    client_main = importlib.import_module("client.main")
+    custom_log_path = tmp_path / "logs" / "cli.log"
+    config = Config.from_dict(
+        {
+            **_config_for_tests(tmp_path).to_dict(),
+            "cli": {"log_path": str(custom_log_path)},
+        }
+    )
+
+    def _fake_load_effective_config(_options):  # noqa: ANN001
+        return object(), config
+
+    async def _forbidden_bootstrap(_options):  # noqa: ANN001
+        raise AssertionError("doctor should not bootstrap runtime")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(client_main, "load_effective_config", _fake_load_effective_config)
+    monkeypatch.setattr(client_main, "bootstrap_runtime", _forbidden_bootstrap)
+
+    rc = await client_main.main(
+        [
+            "--workspace",
+            config.workspace_dir,
+            "--user-dir",
+            config.user_dir,
+            "doctor",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    default_log_path = tmp_path / "dare.log"
+
+    assert rc == 0
+    assert '"ok": true' in output or '"ok": false' in output
+    assert custom_log_path.exists()
+    assert default_log_path.exists() is False
+    assert "DARE CLIENT CLI" in custom_log_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
 async def test_main_script_allows_approvals_command_while_task_running(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -291,6 +390,7 @@ async def test_main_run_auto_approves_configured_tool(
     monkeypatch.setattr(client_main, "bootstrap_runtime", _fake_bootstrap_runtime)
     monkeypatch.setattr(client_main, "TransportActionClient", _FakeActionClient)
     monkeypatch.setattr(client_main, "run_task", _slow_run_task)
+    monkeypatch.chdir(tmp_path)
 
     rc = await client_main.main(
         [
@@ -308,7 +408,9 @@ async def test_main_run_auto_approves_configured_tool(
         ]
     )
     output = capsys.readouterr().out
+    log_text = (tmp_path / "dare.log").read_text(encoding="utf-8")
     assert rc == 0
-    assert "auto-approving request_id=req-auto-1 for tool=run_command" in output
+    assert "auto-approving request_id=req-auto-1 for tool=run_command" not in output
+    assert "auto-approving request_id=req-auto-1 for tool=run_command" in log_text
     assert any(action_id == "approvals:grant" for action_id, _ in _FakeActionClient.calls)
     assert runtime.closed is True

--- a/tests/unit/test_client_cli.py
+++ b/tests/unit/test_client_cli.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import importlib
 import json
+import threading
 import time
 
 import pytest
@@ -732,6 +733,476 @@ async def test_run_chat_interactive_input_does_not_block_event_loop(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_run_chat_interactive_waits_for_completion_before_reprompt(monkeypatch) -> None:
+    client_main = importlib.import_module("client.main")
+    task_finished = threading.Event()
+
+    class _NoopPump:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            return None
+
+        def start(self) -> None:
+            return None
+
+        async def stop(self) -> None:
+            return None
+
+    class _FakeResult:
+        success = True
+        output = "done"
+        errors = None
+
+    async def _fake_run_task(*, agent, task_text, conversation_id=None, transport=None):  # noqa: ANN001
+        _ = (agent, task_text, conversation_id, transport)
+        await asyncio.sleep(0.05)
+        task_finished.set()
+        return _FakeResult()
+
+    input_calls = 0
+
+    def _input(_prompt: str) -> str:
+        nonlocal input_calls
+        input_calls += 1
+        if input_calls == 1:
+            return "do work"
+        assert task_finished.is_set(), "prompt returned before task finished"
+        return "/quit"
+
+    monkeypatch.setattr(client_main, "EventPump", _NoopPump)
+    monkeypatch.setattr(client_main, "run_task", _fake_run_task)
+    monkeypatch.setattr("builtins.input", _input)
+
+    class _FakeRuntime:
+        client_channel = object()
+        config = Config.from_dict({"workspace_dir": ".", "user_dir": "."})
+        model = object()
+        channel = object()
+        agent = object()
+
+    rc = await client_main._run_chat(
+        runtime=_FakeRuntime(),
+        action_client=object(),
+        output=client_main.OutputFacade("json"),
+        mode="execute",
+        script_lines=None,
+    )
+
+    assert rc == 0
+    assert input_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_run_chat_interactive_json_mode_reprompts_when_approval_is_pending(monkeypatch) -> None:
+    client_main = importlib.import_module("client.main")
+    approval_emitted = threading.Event()
+    task_released = asyncio.Event()
+    task_finished = threading.Event()
+
+    class _ApprovalPump:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            self._on_event = kwargs["on_event"]
+            self._task: asyncio.Task[None] | None = None
+
+        def start(self) -> None:
+            self._task = asyncio.create_task(self._emit())
+
+        async def stop(self) -> None:
+            if self._task is None:
+                return
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+
+        async def _emit(self) -> None:
+            await asyncio.sleep(0.05)
+            approval_emitted.set()
+            maybe_awaitable = self._on_event(
+                {
+                    "type": "approval_pending",
+                    "resp": {
+                        "request": {"request_id": "req-1"},
+                        "capability_id": "run_command",
+                        "tool_name": "run_command",
+                    },
+                }
+            )
+            if maybe_awaitable is not None:
+                await maybe_awaitable
+
+    async def _fake_run_task(*, agent, task_text, conversation_id=None, transport=None):  # noqa: ANN001
+        _ = (agent, task_text, conversation_id, transport)
+        await task_released.wait()
+        task_finished.set()
+        return type("OkResult", (), {"success": True, "output": "done", "errors": None})()
+
+    input_calls = 0
+
+    def _input(_prompt: str) -> str:
+        nonlocal input_calls
+        input_calls += 1
+        if input_calls == 1:
+            return "do work"
+        assert approval_emitted.is_set(), "prompt returned before approval pending surfaced"
+        assert task_finished.is_set() is False, "prompt should return while task is still waiting for approval"
+        task_released.set()
+        return "/quit"
+
+    monkeypatch.setattr(client_main, "EventPump", _ApprovalPump)
+    monkeypatch.setattr(client_main, "run_task", _fake_run_task)
+    monkeypatch.setattr("builtins.input", _input)
+
+    class _FakeRuntime:
+        client_channel = object()
+        config = Config.from_dict({"workspace_dir": ".", "user_dir": "."})
+        model = object()
+        channel = object()
+        agent = object()
+
+    rc = await client_main._run_chat(
+        runtime=_FakeRuntime(),
+        action_client=object(),
+        output=client_main.OutputFacade("json"),
+        mode="execute",
+        script_lines=None,
+    )
+
+    assert rc == 0
+    assert input_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_run_chat_interactive_human_mode_prompts_rich_inline_approval_and_grants(monkeypatch, capsys) -> None:
+    client_main = importlib.import_module("client.main")
+    approval_emitted = threading.Event()
+    task_released = asyncio.Event()
+    task_finished = threading.Event()
+    action_calls: list[tuple[str, dict[str, str]]] = []
+
+    class _ApprovalPump:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            self._on_event = kwargs["on_event"]
+            self._task: asyncio.Task[None] | None = None
+
+        def start(self) -> None:
+            self._task = asyncio.create_task(self._emit())
+
+        async def stop(self) -> None:
+            if self._task is None:
+                return
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+
+        async def _emit(self) -> None:
+            await asyncio.sleep(0.05)
+            approval_emitted.set()
+            maybe_awaitable = self._on_event(
+                {
+                    "type": "approval_pending",
+                    "resp": {
+                        "request": {
+                            "request_id": "req-1",
+                            "reason": "Tool run_command requires approval",
+                            "command": "git status",
+                            "params": {"command": "git status", "cwd": "/tmp/workspace"},
+                        },
+                        "capability_id": "run_command",
+                        "tool_name": "run_command",
+                    },
+                }
+            )
+            if maybe_awaitable is not None:
+                await maybe_awaitable
+
+    class _ActionClient:
+        async def invoke_action(self, action, **params):  # noqa: ANN001
+            action_id = action.value if hasattr(action, "value") else str(action)
+            action_calls.append((action_id, {key: str(value) for key, value in params.items()}))
+            task_released.set()
+            return {"ok": True}
+
+    async def _fake_run_task(*, agent, task_text, conversation_id=None, transport=None):  # noqa: ANN001
+        _ = (agent, task_text, conversation_id, transport)
+        await task_released.wait()
+        task_finished.set()
+        return type("OkResult", (), {"success": True, "output": "done", "errors": None})()
+
+    prompts: list[str] = []
+
+    def _input(prompt: str) -> str:
+        prompts.append(prompt)
+        if len(prompts) == 1:
+            assert prompt == "dare> "
+            return "do work"
+        if len(prompts) == 2:
+            assert approval_emitted.wait(timeout=1), "approval prompt rendered before pending event"
+            assert prompt == "approve> "
+            assert task_finished.is_set() is False, "task should still be waiting during approval prompt"
+            return "y"
+        assert task_finished.is_set(), "chat prompt returned before approved task completed"
+        assert prompt == "dare> "
+        return "/quit"
+
+    monkeypatch.setattr(client_main, "EventPump", _ApprovalPump)
+    monkeypatch.setattr(client_main, "run_task", _fake_run_task)
+    monkeypatch.setattr("builtins.input", _input)
+
+    class _FakeRuntime:
+        client_channel = object()
+        config = Config.from_dict({"workspace_dir": ".", "user_dir": "."})
+        model = object()
+        channel = object()
+        agent = object()
+
+    rc = await client_main._run_chat(
+        runtime=_FakeRuntime(),
+        action_client=_ActionClient(),
+        output=client_main.OutputFacade("human"),
+        mode="execute",
+        script_lines=None,
+    )
+
+    assert rc == 0
+    assert prompts == ["dare> ", "approve> ", "dare> "]
+    assert action_calls == [
+        (
+            "approvals:grant",
+            {
+                "request_id": "req-1",
+                "scope": "once",
+                "matcher": "exact_params",
+            },
+        )
+    ]
+    output = capsys.readouterr().out
+    assert "Agent wants to run a shell command." in output
+    assert "Reason: Tool run_command requires approval" in output
+    assert "Command: git status" in output
+    assert "Cwd: /tmp/workspace" in output
+    assert "1. Allow once" in output
+    assert "2. Always allow this exact command in this session" in output
+    assert "3. Deny (default)" in output
+
+
+@pytest.mark.asyncio
+async def test_run_chat_interactive_human_mode_prompts_inline_approval_and_denies(monkeypatch) -> None:
+    client_main = importlib.import_module("client.main")
+    approval_emitted = threading.Event()
+    task_released = asyncio.Event()
+    task_finished = threading.Event()
+    action_calls: list[tuple[str, dict[str, str]]] = []
+
+    class _ApprovalPump:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            self._on_event = kwargs["on_event"]
+            self._task: asyncio.Task[None] | None = None
+
+        def start(self) -> None:
+            self._task = asyncio.create_task(self._emit())
+
+        async def stop(self) -> None:
+            if self._task is None:
+                return
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+
+        async def _emit(self) -> None:
+            await asyncio.sleep(0.05)
+            approval_emitted.set()
+            maybe_awaitable = self._on_event(
+                {
+                    "type": "approval_pending",
+                    "resp": {
+                        "request": {
+                            "request_id": "req-1",
+                            "reason": "Tool run_command requires approval",
+                            "command": "git status",
+                            "params": {"command": "git status", "cwd": "/tmp/workspace"},
+                        },
+                        "capability_id": "run_command",
+                        "tool_name": "run_command",
+                    },
+                }
+            )
+            if maybe_awaitable is not None:
+                await maybe_awaitable
+
+    class _ActionClient:
+        async def invoke_action(self, action, **params):  # noqa: ANN001
+            action_id = action.value if hasattr(action, "value") else str(action)
+            action_calls.append((action_id, {key: str(value) for key, value in params.items()}))
+            task_released.set()
+            return {"ok": True}
+
+    async def _fake_run_task(*, agent, task_text, conversation_id=None, transport=None):  # noqa: ANN001
+        _ = (agent, task_text, conversation_id, transport)
+        await task_released.wait()
+        task_finished.set()
+        return type(
+            "DeniedResult",
+            (),
+            {"success": False, "output": None, "errors": ["tool invocation denied by human approval"]},
+        )()
+
+    prompts: list[str] = []
+
+    def _input(prompt: str) -> str:
+        prompts.append(prompt)
+        if len(prompts) == 1:
+            assert prompt == "dare> "
+            return "do work"
+        if len(prompts) == 2:
+            assert approval_emitted.wait(timeout=1), "approval prompt rendered before pending event"
+            assert prompt == "approve> "
+            assert task_finished.is_set() is False, "task should still be waiting during approval prompt"
+            return "n"
+        assert task_finished.is_set(), "chat prompt returned before denied task completed"
+        assert prompt == "dare> "
+        return "/quit"
+
+    monkeypatch.setattr(client_main, "EventPump", _ApprovalPump)
+    monkeypatch.setattr(client_main, "run_task", _fake_run_task)
+    monkeypatch.setattr("builtins.input", _input)
+
+    class _FakeRuntime:
+        client_channel = object()
+        config = Config.from_dict({"workspace_dir": ".", "user_dir": "."})
+        model = object()
+        channel = object()
+        agent = object()
+
+    rc = await client_main._run_chat(
+        runtime=_FakeRuntime(),
+        action_client=_ActionClient(),
+        output=client_main.OutputFacade("human"),
+        mode="execute",
+        script_lines=None,
+    )
+
+    assert rc == 0
+    assert prompts == ["dare> ", "approve> ", "dare> "]
+    assert action_calls == [
+        (
+            "approvals:deny",
+            {
+                "request_id": "req-1",
+                "scope": "once",
+                "matcher": "exact_params",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_chat_interactive_human_mode_can_remember_same_command_for_session(monkeypatch, capsys) -> None:
+    client_main = importlib.import_module("client.main")
+    approval_emitted = threading.Event()
+    task_released = asyncio.Event()
+    task_finished = threading.Event()
+    action_calls: list[tuple[str, dict[str, str]]] = []
+
+    class _ApprovalPump:
+        def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            self._on_event = kwargs["on_event"]
+            self._task: asyncio.Task[None] | None = None
+
+        def start(self) -> None:
+            self._task = asyncio.create_task(self._emit())
+
+        async def stop(self) -> None:
+            if self._task is None:
+                return
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+
+        async def _emit(self) -> None:
+            await asyncio.sleep(0.05)
+            approval_emitted.set()
+            maybe_awaitable = self._on_event(
+                {
+                    "type": "approval_pending",
+                    "resp": {
+                        "request": {
+                            "request_id": "req-1",
+                            "reason": "Tool run_command requires approval",
+                            "command": "git status",
+                            "params": {"command": "git status", "cwd": "/tmp/workspace"},
+                        },
+                        "capability_id": "run_command",
+                        "tool_name": "run_command",
+                    },
+                }
+            )
+            if maybe_awaitable is not None:
+                await maybe_awaitable
+
+    class _ActionClient:
+        async def invoke_action(self, action, **params):  # noqa: ANN001
+            action_id = action.value if hasattr(action, "value") else str(action)
+            action_calls.append((action_id, {key: str(value) for key, value in params.items()}))
+            task_released.set()
+            return {"ok": True}
+
+    async def _fake_run_task(*, agent, task_text, conversation_id=None, transport=None):  # noqa: ANN001
+        _ = (agent, task_text, conversation_id, transport)
+        await task_released.wait()
+        task_finished.set()
+        return type("OkResult", (), {"success": True, "output": "done", "errors": None})()
+
+    prompts: list[str] = []
+
+    def _input(prompt: str) -> str:
+        prompts.append(prompt)
+        if len(prompts) == 1:
+            assert prompt == "dare> "
+            return "do work"
+        if len(prompts) == 2:
+            assert approval_emitted.wait(timeout=1), "approval prompt rendered before pending event"
+            assert prompt == "approve> "
+            assert task_finished.is_set() is False, "task should still be waiting during approval prompt"
+            return "2"
+        assert task_finished.is_set(), "chat prompt returned before approved task completed"
+        assert prompt == "dare> "
+        return "/quit"
+
+    monkeypatch.setattr(client_main, "EventPump", _ApprovalPump)
+    monkeypatch.setattr(client_main, "run_task", _fake_run_task)
+    monkeypatch.setattr("builtins.input", _input)
+
+    class _FakeRuntime:
+        client_channel = object()
+        config = Config.from_dict({"workspace_dir": ".", "user_dir": "."})
+        model = object()
+        channel = object()
+        agent = object()
+
+    rc = await client_main._run_chat(
+        runtime=_FakeRuntime(),
+        action_client=_ActionClient(),
+        output=client_main.OutputFacade("human"),
+        mode="execute",
+        script_lines=None,
+    )
+
+    assert rc == 0
+    assert prompts == ["dare> ", "approve> ", "dare> "]
+    assert action_calls == [
+        (
+            "approvals:grant",
+            {
+                "request_id": "req-1",
+                "scope": "session",
+                "matcher": "exact_params",
+            },
+        )
+    ]
+    output = capsys.readouterr().out
+    assert "Same command will be auto-approved for the rest of this session." in output
+
+
+@pytest.mark.asyncio
 async def test_main_script_command_missing_file_returns_two(monkeypatch, tmp_path, capsys) -> None:
     client_main = importlib.import_module("client.main")
     workspace = tmp_path / "workspace"
@@ -835,6 +1306,13 @@ def test_default_auto_approve_tools_are_runtime_tool_subset() -> None:
     }
 
     assert client_main.DEFAULT_AUTO_APPROVE_TOOLS.issubset(runtime_tool_names)
+
+
+def test_default_auto_approve_tools_exclude_write_file() -> None:
+    client_main = importlib.import_module("client.main")
+    runtime_bootstrap = importlib.import_module("client.runtime.bootstrap")
+
+    assert runtime_bootstrap.WriteFileTool().name not in client_main.DEFAULT_AUTO_APPROVE_TOOLS
 
 
 def test_cli_raises_system_exit(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_config_model.py
+++ b/tests/unit/test_config_model.py
@@ -86,6 +86,7 @@ def test_config_to_dict_round_trip() -> None:
     config = Config.from_dict(
         {
             "llm": {"adapter": "openai", "model": "gpt-4o", "extra_field": 1},
+            "cli": {"log_path": "/tmp/dare.log"},
             "allow_tools": ["tool_a"],
             "components": {"hook": {"stdout": {"level": "info"}}},
         }
@@ -96,6 +97,7 @@ def test_config_to_dict_round_trip() -> None:
     assert payload["llm"]["adapter"] == "openai"
     assert payload["llm"]["model"] == "gpt-4o"
     assert payload["llm"]["extra_field"] == 1
+    assert payload["cli"]["log_path"] == "/tmp/dare.log"
     assert payload["allow_tools"] == ["tool_a"]
     assert payload["components"]["hook"]["stdout"] == {"level": "info"}
 

--- a/tests/unit/test_config_provider.py
+++ b/tests/unit/test_config_provider.py
@@ -22,6 +22,7 @@ def test_file_config_provider_merges_user_and_workspace(tmp_path: Path) -> None:
         user_dir / ".dare" / "config.json",
         {
             "llm": {"model": "user-model", "proxy": {"use_system_proxy": True}},
+            "cli": {"log_path": "user.log"},
             "allow_tools": ["tool_a"],
             "allow_mcps": ["user_mcp"],
             "mcp": {"user": {"endpoint": "http://user-mcp"}},
@@ -35,6 +36,7 @@ def test_file_config_provider_merges_user_and_workspace(tmp_path: Path) -> None:
                 "model": "workspace-model",
                 "proxy": {"disabled": True, "http": "http://proxy:8080"},
             },
+            "cli": {"log_path": "workspace.log"},
             "allow_mcps": ["workspace_mcp"],
             "tools": {"local_command": {"timeout": 12}},
             "components": {"hook": {"stdout": {"level": "info"}}},
@@ -64,6 +66,7 @@ def test_file_config_provider_merges_user_and_workspace(tmp_path: Path) -> None:
     assert config.llm.proxy.disabled is True
     assert config.llm.proxy.use_system_proxy is False
     assert config.llm.proxy.http is None
+    assert config.cli.log_path == "workspace.log"
     assert config.allow_tools == ["tool_a"]
     assert config.allow_mcps == ["workspace_mcp"]
     assert config.mcp["user"]["endpoint"] == "http://user-mcp"

--- a/tests/unit/test_v4_file_tools.py
+++ b/tests/unit/test_v4_file_tools.py
@@ -74,6 +74,11 @@ async def test_write_file_enforces_max_bytes(tmp_path):
     assert result.output.get("code") == "CONTENT_TOO_LARGE"
 
 
+def test_write_file_requires_approval() -> None:
+    tool = WriteFileTool()
+    assert tool.requires_approval is True
+
+
 @pytest.mark.asyncio
 async def test_search_code_orders_results_deterministically(tmp_path):
     root = tmp_path / "root"


### PR DESCRIPTION
Add file-backed CLI logging with configurable log_path and keep human-mode stdout focused on user interaction.

Update chat mode so prompts stay blocked until a task finishes, and handle approval requests inline in human mode with richer context, one-time approval, session remember behavior, and no extra /approvals round-trip.

Document the new configuration and interaction model, add example config coverage, and change write_file to require approval while removing it from the default auto-approve set. Include regression tests for config loading, chat approval behavior, file-tool approval semantics, and CLI flow.

## Summary
- What does this PR change?
- Why is this change needed?

## Scope (One PR One Thing)
- Primary objective:
- Out of scope:
- I confirm this PR handles a single objective only: [ ] Yes

## Changed Files (required)
List all touched files and why each file changed.

| File | Reason |
| --- | --- |
| path/to/file | reason |

If this PR is a large diff (>300 changed lines), explain why split PRs are not possible and provide a split follow-up plan.

## Acceptance Criteria
- [ ] Criteria 1
- [ ] Criteria 2

## Test Evidence (required)
- Local commands run:
  - `...`
- CI links or job names:
  - `...`
- Evidence/output summary:
  - `...`

If this PR changes high-risk runtime paths (auth/concurrency/execution control), include `risk-matrix` evidence.

## Risk and Rollback
- Risk level: Low / Medium / High
- Main risk points:
- Rollback plan:

## Dependency and Lockfile Changes
- Lockfile changed in this PR: [ ] Yes [ ] No
- If yes, manifest updated in same PR (`requirements.txt`/`pyproject.toml`/`package.json`): [ ] Yes [ ] No [ ] N/A

## Agent Rules Checklist (required)
Reference: `docs/agent_rules.md`

- [ ] Only task-related files changed; no opportunistic refactor
- [ ] Public interfaces/data structures unchanged unless explicitly required
- [ ] Tests added/updated and evidence attached
- [ ] Any `skip/only/exclude` usage is explained and reviewed
- [ ] Merge will be done by approved reviewer (no self-merge auto-ship)
