### PR TITLE
docs(governance): require TODO claim ownership before execution

### DIFF
--- a/.codex/skills/development-workflow/SKILL.md
+++ b/.codex/skills/development-workflow/SKILL.md
@@ -45,16 +45,19 @@ Reference contract: `docs/guides/Evidence_Truth_Implementation_Strategy.md`.
 - choose collaboration mode (OpenSpec default, TODO fallback only when OpenSpec unavailable)
 - complete global analysis before execution
 - build/update a master TODO backlog that covers the full scope
+- declare TODO ownership in the target TODO ledger before implementation (`Claim ID`, `TODO scope`, `owner`, `expires`)
 - update `docs/design/**` first (no implementation before design update)
 - create or refresh feature aggregation doc as the status source
 - initialize/refresh the required evidence block in feature aggregation doc before execution
 - for OpenSpec mode, select one TODO slice as current change scope
+- ensure only one active claim exists per TODO slice; resolve conflicts before coding
 - run `documentation-management` to validate type/path/frontmatter baseline
 
 2. execution-sync
 - OpenSpec mode: execute in small increments `TODO slice item -> OpenSpec task -> implementation -> evidence`
 - TODO fallback mode: execute in small increments `TODO item -> implementation -> evidence`, and record pending OpenSpec migration mapping
 - keep master TODO status and feature aggregation evidence aligned in all modes
+- keep claim ledger aligned with execution state (`planned -> active -> done/released`)
 - after each completed task, update linked design/gap/TODO docs and implementation evidence
 - append command outputs and behavior-check results to the feature evidence block at task granularity
 - for large initiatives, continue by opening the next TODO slice in a new OpenSpec change instead of overloading one change
@@ -63,6 +66,7 @@ Reference contract: `docs/guides/Evidence_Truth_Implementation_Strategy.md`.
 - OpenSpec mode checks: `openspec validate`, `openspec status`, tests, and repo doc checks
 - TODO fallback mode checks: tests, repo doc checks, TODO ledger completeness, and migration debt note completeness
 - verify current OpenSpec slice only claims TODO items actually completed in this slice
+- verify claim ownership is consistent between TODO ledger and feature/OpenSpec slice
 - verify coverage of interface contracts and error branches for changed behavior
 - verify status consistency: feature doc is source of truth, linked docs are non-conflicting
 - verify `docs/**` can stand alone as the current-state record without depending on OpenSpec internals
@@ -77,6 +81,7 @@ Reference contract: `docs/guides/Evidence_Truth_Implementation_Strategy.md`.
 
 5. completion-archive
 - mark work done in feature aggregation and related ledgers
+- release or close TODO claims (`done`/`released`) and clear stale active claims
 - run `documentation-management` archive actions
 - update TODO/archive indexes (for example `docs/todos/README.md` when applicable)
 - OpenSpec mode: complete OpenSpec archive when the change is finished
@@ -91,5 +96,6 @@ For each workflow run, report:
 - evidence commands executed
 - evidence results summary (including changed happy path + error branch checks)
 - evidence file updates (design, TODO, OpenSpec tasks, feature aggregation)
+- claim updates (new/renewed/released claims with TODO scope)
 - review and merge-gate status
 - unresolved risks or migration debt

--- a/docs/guides/Development_Constraints.md
+++ b/docs/guides/Development_Constraints.md
@@ -14,6 +14,7 @@
 - 所有代码开发以 `docs/design/` 全量最新设计为准；若实现与文档冲突，必须先更新文档再改代码。
 - 设计文档必须可独立重建实现：至少显式描述总体架构、核心流程、数据结构、关键接口、异常错误处理（详见 `docs/design/Design_Doc_Minimum_Standard.md`）。
 - 任何 Bug/新增 Feature/重构，必须先执行“全局分析 + 总体 TODO 主清单 + docs 更新”，再按 TODO 切片进入 OpenSpec 流程逐项落地（大改动通常对应多个 OpenSpec change）。
+- 任何进入执行态（`doing`）的 TODO，必须先在对应 TODO 文档登记负责人与认领声明（Claim Ledger：scope/owner/expires/change-id），避免并行冲突。
 - 默认采用 OpenSpec 协作；仅在 OpenSpec 不可用时允许 TODO-driven 回退模式，并必须在 OpenSpec 恢复后完成迁移回写。
 - 任何治理类文档任务必须使用双技能流程（`.codex/skills/documentation-management/SKILL.md` + `.codex/skills/development-workflow/SKILL.md`）或等价自动化流程。
 - Evidence Truth 必须结构化固化到 `docs/features/*.md`，并通过 `./scripts/ci/check_governance_evidence_truth.sh` 门禁校验（见 `docs/guides/Evidence_Truth_Implementation_Strategy.md`）。

--- a/docs/guides/Documentation_First_Development_SOP.md
+++ b/docs/guides/Documentation_First_Development_SOP.md
@@ -47,6 +47,14 @@
 - 基于分析文档生成总体 TODO 主清单，覆盖完整目标范围。
 - 每条 TODO 必须标记切片边界（可独立执行、可独立验证、可独立回滚）。
 - 总体 TODO 必须支持映射多个 OpenSpec change（一个大特性通常对应多个 change）。
+- 每条 TODO 必须有明确 `Owner`；若暂未指定负责人，状态不得进入 `doing`。
+
+### Step 2.5: 负责人认领声明（冲突规避，新增）
+- 在开始实现前，必须先在对应 TODO 文档的 `Claim Ledger` 写入认领声明：
+  - `Claim ID`、`TODO Scope`、`Owner`、`Status(planned/active)`、`Declared At`、`Expires At`、`OpenSpec Change`。
+- 同一 TODO ID 在同一时刻只允许一个 `planned/active` 认领。
+- 认领过期后必须续期或释放（`expired/released`），否则他人可重新认领。
+- 推荐顺序：`先认领 -> 再建/更新 OpenSpec 切片 -> 再进入代码实现`。
 
 ### Step 3: 先更新 docs（作为 OpenSpec 输入）
 - 在执行前先更新 `docs/design/**` 与相关治理文档，形成当前基线。
@@ -98,6 +106,7 @@
 
 - 未完成 Step 1（全局分析）不得进入切片执行。
 - 未完成 Step 2（总体 TODO）不得创建 OpenSpec change。
+- 未完成 Step 2.5（负责人认领声明）不得进入 Step 4/Step 5。
 - 未完成 Step 3（docs 更新）不得进入代码提交。
 - 未完成 Step 4（切片映射）不得开始批量修复。
 - 未完成 Step 6（验证+回写）不得标记切片完成。
@@ -126,20 +135,22 @@
 
 适用于 OpenSpec 可用场景，执行顺序如下：
 1. 先完成分析 + 总体 TODO 主清单 + docs 基线更新。
-2. 从总体 TODO 选择一个切片，建立/选择 `openspec/changes/<change-id>/`。
-3. 创建或更新 `docs/features/<change-id>.md`，登记该切片的 proposal/design/specs/tasks 链接。
-4. 按 OpenSpec tasks 执行该切片，并回写证据到 feature 聚合文档与 TODO 文档。
-5. 重复步骤 2-4，直到总体 TODO 主清单清空。
-6. 完成后执行 verify + archive，并迁移聚合文档到 `docs/features/archive/`。
-7. 确认最终可读性以 `docs/**` 为准：架构/流程/接口变更已在 docs 中可独立理解，OpenSpec 仅保留追踪链接。
+2. 在 TODO `Claim Ledger` 先声明认领（scope/owner/expires/change-id）。
+3. 从总体 TODO 选择一个切片，建立/选择 `openspec/changes/<change-id>/`。
+4. 创建或更新 `docs/features/<change-id>.md`，登记该切片的 proposal/design/specs/tasks 链接。
+5. 按 OpenSpec tasks 执行该切片，并回写证据到 feature 聚合文档与 TODO 文档。
+6. 重复步骤 2-5，直到总体 TODO 主清单清空。
+7. 完成后执行 verify + archive，并迁移聚合文档到 `docs/features/archive/`。
+8. 确认最终可读性以 `docs/**` 为准：架构/流程/接口变更已在 docs 中可独立理解，OpenSpec 仅保留追踪链接。
 
 ### Mode B: 无 OpenSpec 回退（TODO-driven）
 
 仅在 OpenSpec 不可用（工具/环境受限）时使用：
 1. 先完成分析 + 总体 TODO 主清单 + docs 基线更新。
-2. 创建 `docs/features/<topic-slug>.md`，并在 frontmatter 声明 `mode: todo_fallback` 与 `topic_slug`。
-3. 以 TODO 清单推进并持续回写 evidence（不阻塞于 OpenSpec 工具可用性）。
-4. OpenSpec 可用后，按 TODO 切片补迁移：将 fallback 资产映射到一个或多个新的 `openspec/changes/<change-id>/` 并记录迁移证据。
+2. 在 TODO `Claim Ledger` 先声明认领（scope/owner/expires）。
+3. 创建 `docs/features/<topic-slug>.md`，并在 frontmatter 声明 `mode: todo_fallback` 与 `topic_slug`。
+4. 以 TODO 清单推进并持续回写 evidence（不阻塞于 OpenSpec 工具可用性）。
+5. OpenSpec 可用后，按 TODO 切片补迁移：将 fallback 资产映射到一个或多个新的 `openspec/changes/<change-id>/` 并记录迁移证据。
 
 ## 8. SOP Skill 化（必须）
 

--- a/docs/todos/2026-02-27_design_reconstructability_gap_todo.md
+++ b/docs/todos/2026-02-27_design_reconstructability_gap_todo.md
@@ -3,6 +3,15 @@
 > 来源：`docs/todos/2026-02-27_design_reconstructability_gap_analysis.md`  
 > 执行模型：文档先行 -> OpenSpec change -> 实施 -> 回写证据 -> 归档
 
+## 认领声明（Claim Ledger）
+
+> 当前状态：本清单条目均为 `done`，暂无 `planned/active` 认领。  
+> 若未来新增条目，需先登记 Claim 后再进入 `doing`。
+
+| Claim ID | TODO Scope | Owner | Status | Declared At | Expires At | OpenSpec Change | Notes |
+|---|---|---|---|---|---|---|---|
+| N/A | N/A | N/A | released | 2026-03-02 | 2026-03-02 | N/A | 当前无活跃认领。 |
+
 | ID | Priority | Status | Gap ID | Task | Owner | Evidence | Last Updated |
 |---|---|---|---|---|---|---|---|
 | DR-001 | P0 | done | DR-GAP-001 | 建立全局追踪矩阵：每条关键设计约束映射 `doc -> code -> tests -> status`。 | codex | `docs/design/Design_Reconstructability_Traceability_Matrix.md`；`openspec/changes/archive/2026-02-27-close-design-reconstructability-gaps/` | 2026-02-27 |

--- a/docs/todos/2026-02-27_full_design_review_gap_todo.md
+++ b/docs/todos/2026-02-27_full_design_review_gap_todo.md
@@ -3,6 +3,15 @@
 > 来源：`docs/todos/2026-02-27_full_design_review_gap_analysis.md`  
 > 说明：所有项必须映射 Gap ID，并附可定位证据。
 
+## 认领声明（Claim Ledger）
+
+> 当前状态：本清单条目均为 `done`，暂无 `planned/active` 认领。  
+> 若未来新增条目，需先登记 Claim 后再进入 `doing`。
+
+| Claim ID | TODO Scope | Owner | Status | Declared At | Expires At | OpenSpec Change | Notes |
+|---|---|---|---|---|---|---|---|
+| N/A | N/A | N/A | released | 2026-03-02 | 2026-03-02 | N/A | 当前无活跃认领。 |
+
 | ID | Priority | Status | Gap ID | Task | Owner | Evidence | Last Updated |
 |---|---|---|---|---|---|---|---|
 | FR-001 | P0 | done | FR-GAP-001 | 修正 `Architecture.md` 过时运行态断言（step-driven/security）。 | codex | `docs/design/Architecture.md`；`dare_framework/agent/dare_agent.py` | 2026-02-27 |

--- a/docs/todos/README.md
+++ b/docs/todos/README.md
@@ -23,6 +23,8 @@
 - `Priority`：`P0/P1/P2/P3`。
 - `Status`：`todo` / `doing` / `blocked` / `done` / `dropped`。
 - `Owner`：责任人或责任小组。
+- `Claim Status`：`planned` / `active` / `released` / `done` / `expired`。
+- `Claim Expires`：认领过期时间（`YYYY-MM-DD`），用于冲突自动释放。
 - `Evidence`：验证命令、测试结果、PR/commit 或文档链接。
 - `Last Updated`：最后更新时间（`YYYY-MM-DD`）。
 
@@ -30,6 +32,28 @@
 
 `todo -> doing -> done`  
 `todo/doing -> blocked -> doing/dropped`
+
+### 2.1 认领声明（Claim Ledger，新增）
+
+每个**活跃** TODO 文档（存在 `todo/doing/blocked` 项）必须包含 `## 认领声明（Claim Ledger）` 区块，避免多人并行冲突。
+
+建议字段：
+
+- `Claim ID`：唯一认领编号（如 `CLM-20260302-A1`）。
+- `TODO Scope`：被认领的 TODO ID 范围（如 `D2-1~D2-4,D4-1~D4-4`）。
+- `Owner`：当前负责人（个人或小组）。
+- `Status`：`planned`（声明未开工）/`active`（执行中）/`released`（释放）/`done`（完成）/`expired`（过期）。
+- `Declared At`：声明时间（`YYYY-MM-DD`）。
+- `Expires At`：过期时间（建议 3-7 天，超时需续期或释放）。
+- `OpenSpec Change`：对应 change-id（若未创建写 `pending`）。
+- `Notes`：冲突说明、续期原因或交接备注。
+
+执行规则：
+
+- 在 TODO 从 `todo` 进入 `doing` 前，必须先写入认领声明。
+- 同一 TODO ID 在同一时刻只能有一个 `planned/active` 认领。
+- 到期未续期的认领应转为 `expired`，并允许他人重新认领。
+- 完成或暂停时，必须把认领状态回写为 `done/released`。
 
 ## 3. 更新规则
 
@@ -41,6 +65,7 @@
   - 只记录“全局事项”，不写单个 feature 的实现细节；
   - 变更 TODO 时同步更新时间；
   - `done` 项必须补 `Evidence`。
+  - 进入执行前必须更新认领声明（Owner/Scope/Expires）。
   - 全量设计评审（Architecture + 全部模块 README）至少每两周执行一次，并回写到 `project_overall_todos.md`。
 
 ## 4. 归档规则

--- a/docs/todos/agentscope_domain_execution_todos.md
+++ b/docs/todos/agentscope_domain_execution_todos.md
@@ -1,6 +1,6 @@
 # AgentScope 迁移 Domain 执行清单（详细设计输入版，4人协同）
 
-> 更新日期：2026-02-26  
+> 更新日期：2026-03-02  
 > 输入基线：  
 > - `docs/design/archive/agentscope-migration-framework-gaps.md`  
 > - `examples/10-agentscope-compat-single-agent/DESIGN.md`  
@@ -13,6 +13,18 @@
 - 不做 HITL 闭环；本轮关注完整权限模型与工具调用权限治理。
 - `client send` 升级为：`content: string` + `uris: list` + `metadata`。
 - `context.assemble` 负责把 `content + uris` 归一化为内部 message 结构。
+
+## 0.1 认领声明（Claim Ledger）
+
+> 用途：对本清单中的 TODO 先做执行声明，避免多人并行修改同一子域。  
+> 规则：同一 TODO Scope 同时仅允许一个 `planned/active` 认领；到期需续期或释放。
+
+| Claim ID | TODO Scope | Owner | Status | Declared At | Expires At | OpenSpec Change | Notes |
+|---|---|---|---|---|---|---|---|
+| CLM-20260302-D2D4 | D2-1~D2-4, D4-1~D4-4 | mindfn | planned | 2026-03-02 | 2026-03-09 | `agentscope-d2-d4-thinking-transport` | 先处理 P0/P1 的 thinking 与 transport 协议统一。 |
+| CLM-20260302-D5 | D5-1~D5-4 | mindfn | planned | 2026-03-02 | 2026-03-09 | `agentscope-d5-safe-compression` | 压缩链路：tool pair safe + token-aware + auto trigger。 |
+| CLM-20260302-D7 | D7-1~D7-4 | mindfn | planned | 2026-03-02 | 2026-03-09 | `agentscope-d7-plan-state-tools` | plan 状态机与 finish/revise 原生工具补齐。 |
+| CLM-20260302-D1D3 | D1-1~D1-4, D3-1~D3-4 | mindfn | planned | 2026-03-02 | 2026-03-09 | `agentscope-d1-d3-message-pipeline` | 多模态输入 schema 与 assemble normalize。 |
 
 ---
 

--- a/docs/todos/project_overall_todos.md
+++ b/docs/todos/project_overall_todos.md
@@ -1,12 +1,24 @@
 # DARE Framework 项目总体 TODO
 
-> 更新时间：2026-03-01  
+> 更新时间：2026-03-02  
 > 范围：项目全局演进（非单个 feature 的实现方案）
 
 ## 1. 目标与边界
 
 - 目标：持续收敛 `docs/design` 目标架构与 `dare_framework/` 当前实现，优先保证可运行、可验证、可审计。
 - 边界：这里只记录跨模块、跨阶段事项；具体任务拆解进入 OpenSpec 与模块文档。
+
+## 1.1 认领声明（Claim Ledger）
+
+> 用途：在进入执行前先声明 TODO 负责人与范围，避免多人并行冲突。  
+> 规则：同一 TODO Scope 同时仅允许一个 `planned/active` 认领；过期需续期或释放。
+
+| Claim ID | TODO Scope | Owner | Status | Declared At | Expires At | OpenSpec Change | Notes |
+|---|---|---|---|---|---|---|---|
+| CLM-20260302-AG1 | T5-2 | mindfn | planned | 2026-03-02 | 2026-03-09 | `agentscope-d2-d4-thinking-transport` | 对齐 D2/D4：thinking + transport 事件链路。 |
+| CLM-20260302-AG2 | T2-1 | mindfn | planned | 2026-03-02 | 2026-03-09 | `agentscope-d5-safe-compression` | 对齐 D5：安全压缩与预算收敛。 |
+| CLM-20260302-AG3 | D7-1~D7-4（关联 T5-5） | mindfn | planned | 2026-03-02 | 2026-03-09 | `agentscope-d7-plan-state-tools` | 先按 AgentScope gap 切片推进 plan 状态机能力。 |
+| CLM-20260302-AG4 | T5-3 | mindfn | planned | 2026-03-02 | 2026-03-09 | `agentscope-d1-d3-message-pipeline` | 对齐 D1/D3：多模态输入 schema + normalize。 |
 
 ## 2. 当前基线
 


### PR DESCRIPTION
## Summary
- add a repository-wide `Claim Ledger` contract in TODO governance docs (`docs/todos/README.md`), including claim status and expiry semantics
- enforce claim declaration before implementation in SOP/constraints (`Step 2.5` + DoD gate)
- sync workflow skill checkpoint requirements so claim lifecycle is tracked through kickoff/execution/verification/archive
- add claim ledger sections to active TODO ledgers and pre-declare current AgentScope execution slices with owner `mindfn`

## Why
This introduces an explicit ownership declaration step for TODO slices to prevent parallel execution conflicts and keep ownership auditable across TODO/OpenSpec workflows.

## Verification
- `./scripts/ci/check_design_doc_drift.sh` (pass)

## Notes
- PR intentionally excludes unrelated untracked local files (`dare.log`, `docs/plans/`).