### PR TITLE
Harden retrospective process governance

### DIFF
--- a/.codex/skills/development-workflow/SKILL.md
+++ b/.codex/skills/development-workflow/SKILL.md
@@ -98,6 +98,7 @@ Reference contract: `docs/guides/Evidence_Truth_Implementation_Strategy.md`.
 - TODO fallback mode: archive fallback docs/ledgers and keep an explicit migration plan/status until OpenSpec migration is completed
 - if master TODO still has pending slices, keep initiative active and start next slice workflow
 - ensure archived entries stay discoverable via index/evidence links
+- if the human explicitly asks for lessons learned or workflow hardening after completion, hand off to `.codex/skills/retrospective-process-hardening/SKILL.md` instead of embedding ad-hoc retrospective rules here
 
 ## Output expectations
 For each workflow run, report:

--- a/.codex/skills/retrospective-process-hardening/SKILL.md
+++ b/.codex/skills/retrospective-process-hardening/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: retrospective-process-hardening
+description: Use when a completed feature, bugfix, or refactor needs lessons learned distilled into reusable workflow rules, SOP updates, or skill changes.
+---
+
+# Retrospective Process Hardening
+
+## Overview
+
+Convert one completed delivery cycle into durable process improvements.
+
+This skill exists to prevent two common failures:
+- overfitting lessons to the domain of the just-finished change
+- dumping every observation into SOPs instead of classifying what should become a rule, a skill update, a new skill, or nothing
+
+**Baseline failure this skill is designed to catch:** after a complex change, the first draft of "lessons learned" often mirrors the current module or protocol instead of extracting reusable engineering practice.
+
+## When to Use
+
+Use this skill only when a human explicitly asks to:
+- summarize lessons learned
+- update workflow norms or SOPs based on completed work
+- decide whether to create or update a skill from recent delivery experience
+
+Do not use this skill:
+- before implementation is materially complete
+- for ordinary progress updates
+- for domain design writeups that are not intended to become process guidance
+
+## Core Rule
+
+Retrospective output must be classified before it is codified.
+
+Every candidate lesson must end in exactly one bucket:
+1. `update-sop`
+2. `update-existing-skill`
+3. `create-new-skill`
+4. `do-not-codify`
+
+If a lesson cannot survive that classification, it is not ready to become process guidance.
+
+## Process
+
+### 1. Gather evidence
+
+Build the retrospective from concrete evidence, not impression:
+- change scope
+- review findings
+- rework or rollback points
+- design corrections
+- verification gaps
+- documentation drift
+
+Prefer repository evidence over memory:
+- diff scope
+- review comments
+- docs/spec updates
+- tests added or corrected
+
+### 2. Extract candidate lessons
+
+Write short candidate lessons in neutral language.
+
+<Good>
+- Structural changes need an explicit scope freeze before implementation.
+- Public API unions should be normalized at the boundary instead of propagating inward.
+</Good>
+
+<Bad>
+- Rich-media messages should not use `Task.description`.
+- Approval payloads should be `select`.
+</Bad>
+
+The bad examples may be true for the specific change, but they are domain decisions, not reusable process rules.
+
+### 3. Abstract before classifying
+
+For each candidate lesson, ask:
+- Is this still true outside the current domain?
+- Does it guide future decisions rather than restate this implementation?
+- Would this help on unrelated features?
+
+If the answer is no, move it to `do-not-codify`.
+
+## Classification rules
+
+### `update-sop`
+
+Use when the lesson is:
+- generally applicable across feature work
+- a mandatory workflow or governance rule
+- something contributors should follow even without special prompting
+
+Typical examples:
+- scope freeze before structural change
+- entry-inventory requirement before schema/protocol changes
+- global sweep before declaring completion
+
+### `update-existing-skill`
+
+Use when the lesson:
+- fits the responsibility of an existing skill
+- improves an existing skill's trigger, guardrails, or output contract
+- does not justify a standalone reusable workflow
+
+Typical examples:
+- refine `development-workflow` to mention a closing checkpoint
+- strengthen `documentation-management` archive rules
+
+### `create-new-skill`
+
+Use when the lesson describes a reusable decision workflow that:
+- is too detailed for SOP prose
+- benefits from classification steps, examples, or anti-patterns
+- should only run under explicit triggering conditions
+
+Typical examples:
+- a dedicated retrospective-to-process-hardening workflow
+- a cross-cutting debugging discipline with repeatable pressure cases
+
+### `do-not-codify`
+
+Use when the lesson is:
+- domain-specific
+- a one-off repository cleanup detail
+- already implied by an existing rule
+- better enforced by code or CI than by prose
+
+## Output contract
+
+Produce four sections in order:
+
+1. `Evidence`
+- concise list of the specific completed work and review signals used
+
+2. `Candidate Lessons`
+- short neutral statements
+
+3. `Classification`
+- one line per lesson with exactly one bucket:
+  - `update-sop`
+  - `update-existing-skill`
+  - `create-new-skill`
+  - `do-not-codify`
+
+4. `Codified Changes`
+- the actual file updates required
+- keep only the highest-value general rules
+
+## Codification guardrails
+
+- SOPs should contain triggers, mandatory gates, and durable process rules
+- skills should contain the detailed method and classification logic
+- do not duplicate the same detailed workflow in both places
+- if the detailed reasoning belongs in a skill, keep the SOP reference short
+- prefer changing an existing skill before creating a new one
+
+## Common mistakes
+
+### Turning implementation details into workflow law
+
+If the lesson names a current module, payload, adapter, or schema, it is probably not abstract enough yet.
+
+### Codifying everything
+
+A good retrospective is selective. Most observations should never become process rules.
+
+### Using the skill without explicit human request
+
+This skill is opt-in. It should not run automatically after every change.
+
+### Updating SOP first and figuring out the method later
+
+If the lesson needs a decision workflow, create or update the skill first, then reference it from SOP.

--- a/docs/guides/Development_Constraints.md
+++ b/docs/guides/Development_Constraints.md
@@ -14,6 +14,7 @@
 - 所有代码开发以 `docs/design/` 全量最新设计为准；若实现与文档冲突，必须先更新文档再改代码。
 - 设计文档必须可独立重建实现：至少显式描述总体架构、核心流程、数据结构、关键接口、异常错误处理（详见 `docs/design/Design_Doc_Minimum_Standard.md`）。
 - 任何 Bug/新增 Feature/重构，必须先执行“全局分析 + 总体 TODO 主清单 + docs 更新”，再按 TODO 切片进入 OpenSpec 流程逐项落地（大改动通常对应多个 OpenSpec change）。
+- 结构性改造（接口/schema/protocol/state model/workflow 边界调整）在进入实现前，必须显式完成 scope freeze：至少写清 `in scope`、`out of scope`、`deferred`。
 - 任何进入实现态的切片，必须先完成 `Claim Ledger` 认领声明，并先合入 docs-only `spec-sync / intent PR`；未合入前不得开始代码实现。
 - 实现态门禁由 `./scripts/ci/check_governance_intent_gate.sh` 强制执行：一旦 PR 涉及实现路径改动，必须同 PR 更新至少一个 `docs/features/*.md`（`status: active|in_review`）并提供已合并的 `Intent PR` 链接。
 - 默认采用 OpenSpec 协作；仅在 OpenSpec 不可用时允许 TODO-driven 回退模式，并必须在 OpenSpec 恢复后完成迁移回写。
@@ -27,6 +28,9 @@
 - 接口优先：先定义/复用抽象接口，后实现；遵循 SOLID/DRY/KISS，小函数、小对象，避免静态全局单例。默认使用 `ABC` 定义框架接口；仅在确需结构化子类型匹配时使用 `Protocol`（当前优先用于 Model 相关抽象）。
 - 依赖注入：通过构造器或显式参数传递依赖，不隐式从全局获取，以便测试和替换。
 - 数据约束：使用 Pydantic 或严格类型别名表达输入输出，不信任 LLM 生成的字段；所有函数/方法必须完整类型标注。Domain 层禁止通过字符串解析推断行为，必须使用强类型（枚举/数据对象）表达语义。
+- 边界归一：公共输入边界允许存在有限 sugar，但进入系统后必须尽快归一为单一 canonical 内部类型；禁止将 union 输入类型持续传播到内部执行链路。
+- 入口清单：任何接口/schema/protocol 改造，在编码前必须盘点所有入口与旁路，包括 public API、transport、client helper、examples、tests、adapter、持久化与文档；未完成入口盘点不得开始实现。
+- 封闭域与扩展槽分离：强类型默认用于封闭且稳定的语义域；承担扩展能力的开放槽位不得误收死为封闭枚举。
 - 兼容策略：当前仓库处于开发阶段，不为历史行为保留保护性兼容分支或回退逻辑；发现设计问题优先重构到清晰职责边界。
 - Python 版本策略：最低兼容版本为 Python `3.12`，不再为 Python `3.11` 及更老版本添加兼容代码。
 
@@ -61,3 +65,4 @@
 - 代码通过 `ruff`/`black`/`mypy`/`pytest`，接口/公共函数有 docstring，命名清晰。
 - 日志/审计点到位，敏感数据已脱敏，EventLog 记录关键操作。
 - 代码改动前已完成设计文档更新；存在对应 gap 分析文档与 TODO 清单，并与 OpenSpec 任务一一对应。
+- 结构性改造完成前已执行一次全局回扫：代码、测试、examples、active docs、规范文档与归档状态不存在旧契约残留。

--- a/docs/guides/Documentation_First_Development_SOP.md
+++ b/docs/guides/Documentation_First_Development_SOP.md
@@ -40,6 +40,7 @@
 
 ### Step 1: 全局分析（先于执行）
 - 对任务做完整分析：现状、目标、影响范围、风险、依赖、边界。
+- 若属于结构性改造（接口/schema/protocol/state model/workflow 边界调整），必须在分析阶段完成 scope freeze：明确 `in scope`、`out of scope`、`deferred`。
 - 产出或更新 gap 分析文档，确保每条分析有文档/代码证据锚点。
 - 大改动必须先得到“可拆分切片”的分析结论，禁止直接进入执行。
 
@@ -57,6 +58,7 @@
 
 ### Step 3: 先更新 docs（作为 OpenSpec 输入）
 - 在执行前先更新 `docs/design/**` 与相关治理文档，形成当前基线。
+- 对接口/schema/protocol 改造，docs 更新前必须先列出入口清单：public API、transport、client helper、examples、tests、adapter、持久化、文档/guide。
 - TODO 与 design 是 OpenSpec proposal/design 的输入，不是执行后补写。
 - 若缺文档，先补文档，不允许“先写代码再补文档”。
 - 文档结构必须满足最小标准（见 `Design_Doc_Minimum_Standard.md`）。
@@ -102,6 +104,7 @@
   - `Review and Merge Gate Links`
 - 必须执行并通过：`./scripts/ci/check_governance_evidence_truth.sh`。
 - 对实现路径变更 PR，必须执行并通过：`./scripts/ci/check_governance_intent_gate.sh`。
+- 对结构性改造，Step 6 结束前必须执行一次全局回扫：确认代码、测试、examples、active docs、规范文档、归档索引中不存在旧接口/旧协议/旧术语残留。
 
 ### Step 7: 归档
 - 总体 TODO 全部切片完成后：
@@ -189,5 +192,13 @@ SOP 关键阶段必须有可调用技能承载，并保持 checkpoint 与 skill 
   - `.codex/skills/documentation-management/SKILL.md`
 - 开发流程技能（模式选择/checkpoint/证据回写）：
   - `.codex/skills/development-workflow/SKILL.md`
+- 经验沉淀技能（仅在用户明确要求总结经验/刷新流程时触发）：
+  - `.codex/skills/retrospective-process-hardening/SKILL.md`
+
+经验沉淀技能的职责边界：
+- 抽取已完成工作的 lessons learned
+- 将候选经验分类为 `update-sop` / `update-existing-skill` / `create-new-skill` / `do-not-codify`
+- 仅将经过分类筛选的高价值通用规则回写到 SOP/skill
+- 不得把 domain-specific 设计结论直接写成通用流程规则
 
 若 SOP 与 skill 行为不一致，以规范文档更新 + skill 同步更新为同一任务，禁止只改其一。


### PR DESCRIPTION
## Summary
- add a dedicated `retrospective-process-hardening` skill for converting completed delivery lessons into reusable process changes
- update the development workflow skill to delegate explicit lessons-learned requests to the new retrospective skill
- strengthen SOP/constraints with reusable structural-change rules: scope freeze, boundary normalization, entry inventory, closed-vs-open field distinction, and a mandatory global sweep before completion

## Validation
- `git diff --check`

## Notes
- this PR is intentionally separate from the rich-media message pipeline work
- the new skill is opt-in and should only be used when a human explicitly requests lessons learned or workflow hardening