### PR TITLE
fix(runtime): restore __init__.py facade compliance for T0-4

### DIFF
--- a/dare_framework/compression/__init__.py
+++ b/dare_framework/compression/__init__.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from .moving_compression import MovingCompressor
+from dare_framework.compression.moving_compression import MovingCompressor
 
 __all__ = ["MovingCompressor"]
 

--- a/dare_framework/embedding/__init__.py
+++ b/dare_framework/embedding/__init__.py
@@ -2,7 +2,7 @@
 
 from dare_framework.embedding.interfaces import IEmbeddingAdapter
 from dare_framework.embedding.types import EmbeddingOptions, EmbeddingResult
-from dare_framework.embedding._internal.openai_embedding import OpenAIEmbeddingAdapter
+from dare_framework.embedding._internal import OpenAIEmbeddingAdapter
 
 __all__ = [
     "IEmbeddingAdapter",

--- a/dare_framework/embedding/_internal/__init__.py
+++ b/dare_framework/embedding/_internal/__init__.py
@@ -1,1 +1,5 @@
 """Embedding domain internal implementations."""
+
+from dare_framework.embedding._internal.openai_embedding import OpenAIEmbeddingAdapter
+
+__all__ = ["OpenAIEmbeddingAdapter"]

--- a/dare_framework/event/__init__.py
+++ b/dare_framework/event/__init__.py
@@ -1,6 +1,6 @@
 """event domain facade."""
 
-from dare_framework.event._internal.sqlite_event_log import DefaultEventLog, SQLiteEventLog
+from dare_framework.event._internal import DefaultEventLog, SQLiteEventLog
 from dare_framework.event.kernel import IEventLog
 from dare_framework.event.types import Event, RuntimeSnapshot
 

--- a/dare_framework/hook/__init__.py
+++ b/dare_framework/hook/__init__.py
@@ -2,7 +2,7 @@
 
 from dare_framework.hook.interfaces import IHookManager
 from dare_framework.hook.kernel import IExtensionPoint, IHook, HookFn
-from dare_framework.hook._internal.hook_extension_point import HookExtensionPoint
+from dare_framework.hook._internal import HookExtensionPoint
 from dare_framework.hook.types import HookDecision, HookEnvelope, HookPhase, HookResult
 
 __all__ = [

--- a/dare_framework/hook/_internal/__init__.py
+++ b/dare_framework/hook/_internal/__init__.py
@@ -2,3 +2,7 @@
 
 from __future__ import annotations
 
+from dare_framework.hook._internal.hook_extension_point import HookExtensionPoint
+
+__all__ = ["HookExtensionPoint"]
+

--- a/dare_framework/observability/_internal/__init__.py
+++ b/dare_framework/observability/_internal/__init__.py
@@ -1,0 +1,31 @@
+"""Observability internal implementations (non-public).
+
+Re-exports concrete helpers so the domain facade can import from
+``dare_framework.observability._internal`` without reaching into leaf modules.
+"""
+
+from dare_framework.observability._internal.event_trace_bridge import (
+    TraceAwareEventLog,
+    TraceContext,
+)
+from dare_framework.observability._internal.llm_io_capture_hook import LLMIOCaptureHook
+from dare_framework.observability._internal.metrics_collector import MetricsCollector
+from dare_framework.observability._internal.otel_provider import (
+    DAREAttributes,
+    GenAIAttributes,
+    NoOpTelemetryProvider,
+    OTelTelemetryProvider,
+)
+from dare_framework.observability._internal.tracing_hook import ObservabilityHook
+
+__all__ = [
+    "DAREAttributes",
+    "GenAIAttributes",
+    "LLMIOCaptureHook",
+    "MetricsCollector",
+    "NoOpTelemetryProvider",
+    "OTelTelemetryProvider",
+    "ObservabilityHook",
+    "TraceAwareEventLog",
+    "TraceContext",
+]

--- a/dare_framework/plan/__init__.py
+++ b/dare_framework/plan/__init__.py
@@ -23,8 +23,7 @@ from dare_framework.plan.types import (
     ValidatedStep,
     VerifyResult,
 )
-from dare_framework.plan._internal.default_planner import DefaultPlanner
-from dare_framework.plan._internal.default_remediator import DefaultRemediator
+from dare_framework.plan._internal import DefaultPlanner, DefaultRemediator
 
 __all__ = [
     # Interfaces

--- a/dare_framework/plan/_internal/__init__.py
+++ b/dare_framework/plan/_internal/__init__.py
@@ -5,3 +5,11 @@ implementations or building blocks for custom composition.
 """
 
 from __future__ import annotations
+
+from dare_framework.plan._internal.default_planner import DefaultPlanner
+from dare_framework.plan._internal.default_remediator import DefaultRemediator
+
+__all__ = [
+    "DefaultPlanner",
+    "DefaultRemediator",
+]

--- a/dare_framework/security/__init__.py
+++ b/dare_framework/security/__init__.py
@@ -1,6 +1,6 @@
 """Security domain facade."""
 
-from dare_framework.security._internal.default_security_boundary import DefaultSecurityBoundary
+from dare_framework.security._internal import DefaultSecurityBoundary
 from dare_framework.security.errors import (
     SECURITY_APPROVAL_MANAGER_MISSING,
     SECURITY_POLICY_CHECK_FAILED,

--- a/tests/unit/test_package_initializers_facade_pattern.py
+++ b/tests/unit/test_package_initializers_facade_pattern.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 
 
 def test_package_initializers_follow_facade_pattern() -> None:
     """Asserts that all dare_framework initializers use the facade pattern.
-    
+
     Rules:
     1. Must have a docstring.
     2. No class or function definitions.
@@ -22,11 +23,11 @@ def test_package_initializers_follow_facade_pattern() -> None:
     for path in init_files:
         source = path.read_text(encoding="utf-8")
         if not source.strip():
-             # Empty files are okay if they are just placeholders, 
-             # but the user wanted docstrings.
-             violations.append(f"{path.relative_to(repo_root)}: Missing docstring")
-             continue
-             
+            # Empty files are okay if they are just placeholders,
+            # but the user wanted docstrings.
+            violations.append(f"{path.relative_to(repo_root)}: Missing docstring")
+            continue
+
         module = ast.parse(source, filename=str(path))
         body = module.body
 
@@ -40,12 +41,15 @@ def test_package_initializers_follow_facade_pattern() -> None:
             violations.append(f"{path.relative_to(repo_root)}: Missing docstring at top of file")
             continue
 
-        body = body[1:] # Skip docstring
+        body = body[1:]  # Skip docstring
 
         for node in body:
             # Rule 2: No class or function definitions
             if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
-                violations.append(f"{path.relative_to(repo_root)}: Prohibited definition ({type(node).__name__})")
+                violations.append(
+                    f"{path.relative_to(repo_root)}: "
+                    f"Prohibited definition ({type(node).__name__})"
+                )
                 continue
 
             # Rule 3: Assignments allowed only for metadata
@@ -55,7 +59,7 @@ def test_package_initializers_follow_facade_pattern() -> None:
                     targets = node.targets
                 else:
                     targets = [node.target]
-                
+
                 valid_assignment = True
                 for target in targets:
                     if isinstance(target, ast.Name):
@@ -63,16 +67,133 @@ def test_package_initializers_follow_facade_pattern() -> None:
                             valid_assignment = False
                     else:
                         valid_assignment = False
-                
+
                 if not valid_assignment:
-                    violations.append(f"{path.relative_to(repo_root)}: Prohibited assignment (only __all__/__version__ etc allowed)")
+                    violations.append(
+                        f"{path.relative_to(repo_root)}: "
+                        "Prohibited assignment (only __all__/__version__ etc allowed)"
+                    )
 
             # Rule 4: Imports are allowed (for re-exporting)
             if isinstance(node, (ast.Import, ast.ImportFrom)):
                 continue
-            
+
             # Allow metadata assignments and imports, but flag anything else
             if not isinstance(node, (ast.Assign, ast.AnnAssign, ast.Import, ast.ImportFrom)):
-                violations.append(f"{path.relative_to(repo_root)}: Prohibited node type ({type(node).__name__})")
+                violations.append(
+                    f"{path.relative_to(repo_root)}: "
+                    f"Prohibited node type ({type(node).__name__})"
+                )
 
-    assert not violations, "Package initializers violated facade pattern rules:\n" + "\n".join(violations)
+    assert not violations, (
+        "Package initializers violated facade pattern rules:\n" + "\n".join(violations)
+    )
+
+
+def test_all_internal_dirs_have_init() -> None:
+    """Every ``_internal/`` directory under dare_framework MUST contain ``__init__.py``."""
+    repo_root = Path(__file__).resolve().parents[2]
+    package_root = repo_root / "dare_framework"
+
+    internal_dirs = sorted(package_root.rglob("_internal"))
+    internal_dirs = [d for d in internal_dirs if d.is_dir()]
+    assert internal_dirs, "Expected to find _internal directories"
+
+    missing: list[str] = []
+    for d in internal_dirs:
+        init_path = d / "__init__.py"
+        if not init_path.exists():
+            missing.append(str(d.relative_to(repo_root)))
+
+    assert not missing, (
+        "_internal directories missing __init__.py:\n" + "\n".join(missing)
+    )
+
+
+def test_domain_init_does_not_import_internal_leaf_modules() -> None:
+    """Domain ``__init__.py`` MUST import from ``_internal`` package, not leaf modules.
+
+    Allowed:
+        from dare_framework.plan._internal import DefaultPlanner
+    Forbidden:
+        from dare_framework.plan._internal.default_planner import DefaultPlanner
+
+    The ``tool`` domain is excluded because it uses a ``_exports`` module pattern
+    rather than ``_internal`` for lazy loading.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    package_root = repo_root / "dare_framework"
+
+    # Pattern matches imports like ``from dare_framework.X._internal.Y import ...``
+    # where Y is a leaf submodule file (i.e. there is a dot after _internal).
+    leaf_import_re = re.compile(r"from\s+\S+\._internal\.\S+\s+import")
+
+    violations: list[str] = []
+
+    # Only check domain-level __init__.py (direct children of dare_framework/)
+    for domain_dir in sorted(package_root.iterdir()):
+        if not domain_dir.is_dir():
+            continue
+        init_path = domain_dir / "__init__.py"
+        if not init_path.exists():
+            continue
+
+        source = init_path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(source.splitlines(), start=1):
+            # Skip comments
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue
+            if leaf_import_re.search(line):
+                rel = init_path.relative_to(repo_root)
+                violations.append(f"{rel}:{lineno}: {stripped}")
+
+    assert not violations, (
+        "Domain __init__.py files import directly from _internal leaf modules "
+        "(must import through _internal/__init__.py):\n" + "\n".join(violations)
+    )
+
+
+def test_domain_init_defines_all() -> None:
+    """Every domain-level ``__init__.py`` MUST define ``__all__``.
+
+    The top-level ``dare_framework/__init__.py`` is excluded from this check
+    because it is an acceptable empty-``__all__`` placeholder.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    package_root = repo_root / "dare_framework"
+
+    missing: list[str] = []
+
+    for domain_dir in sorted(package_root.iterdir()):
+        if not domain_dir.is_dir():
+            continue
+        # Skip __pycache__ and similar
+        if domain_dir.name.startswith("__"):
+            continue
+        init_path = domain_dir / "__init__.py"
+        if not init_path.exists():
+            continue
+
+        source = init_path.read_text(encoding="utf-8")
+        if not source.strip():
+            # Empty placeholder -- already flagged by the docstring test
+            continue
+
+        tree = ast.parse(source, filename=str(init_path))
+        has_all = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name) and target.id == "__all__":
+                        has_all = True
+                        break
+            if has_all:
+                break
+
+        if not has_all:
+            missing.append(str(init_path.relative_to(repo_root)))
+
+    assert not missing, (
+        "Domain __init__.py files missing __all__:\n" + "\n".join(missing)
+    )


### PR DESCRIPTION
## Summary
- move public package exports back behind supported facade boundaries
- add internal package initializers where needed so public imports stop reaching into `._internal`
- strengthen facade regression coverage for the affected runtime packages

## Test Plan
- [x] `.venv/bin/pytest -q tests/unit/test_package_initializers_facade_pattern.py tests/unit/test_event_log.py tests/unit/test_hook_contract_types.py tests/unit/test_default_planner.py tests/unit/test_security_boundary.py tests/unit/test_embedding_openai_adapter.py tests/unit/test_observability.py`

## Notes
- This supersedes the earlier closed T0-4/T0-5 bundle by isolating the T0-4 facade fix into its own PR.